### PR TITLE
Incompatibility exposed with interaction of varArgs and any

### DIFF
--- a/examples/browser.html
+++ b/examples/browser.html
@@ -28,7 +28,7 @@
   };
 
   function printNode(node, path) {
-    path = (path || '').concat((node.param && node.param.types.toString()) || '');
+    path = (path || '').concat((node.param && node.param.toString()) || '');
     return node.childs.length
       ? node.childs.reduce(function(paths, child) { return paths.concat(printNode(child, path)); }, [])
       : [path];

--- a/examples/browser.html
+++ b/examples/browser.html
@@ -15,6 +15,25 @@
 
   // use the function
   document.write(fn1(2, 'foo') + '<br>'); // outputs 'a is a number, b is a string'
+
+  var fn = function() {
+    return typed({
+      'any,any': function() { return 'two'; },
+      'number,number,string': function() { return 'three'; }
+    });
+  };
+
+  var printParams = function(params) {
+    return params.map(function(p) { return p.types.join('|'); }).join(',');
+  };
+
+  function printNode(node, path) {
+    path = (path || '').concat((node.param && node.param.types.toString()) || '');
+    return node.childs.length
+      ? node.childs.reduce(function(paths, child) { return paths.concat(printNode(child, path)); }, [])
+      : [path];
+  };
+
 </script>
 </body>
 </html>

--- a/test/any_type.test.js
+++ b/test/any_type.test.js
@@ -120,8 +120,7 @@ describe('any type', function () {
     assert.throws(function () {fn()}, /TypeError: Too few arguments in function unnamed \(expected: Array or any, index: 0\)/);
   });
 
-  // FIXME: should should permit multi-layered use of any. See https://github.com/josdejong/typed-function/pull/8
-  it.skip('should permit multi-layered use of any', function() {
+  it('should permit multi-layered use of any', function() {
     var fn = typed({
       'any,any': function () {
         return 'two';

--- a/test/any_type.test.js
+++ b/test/any_type.test.js
@@ -80,7 +80,7 @@ describe('any type', function () {
     assert.equal(fn('foo', 2), 'string,any');
     assert.equal(fn([]), 'any');
     assert.equal(fn('foo'), 'any');
-    assert.throws(function () {fn()}, /TypeError: Too few arguments in function unnamed \(expected: string or any, index: 0\)/);
+    assert.throws(function () {fn()}, /TypeError: Too few arguments in function unnamed \(expected: any or string, index: 0\)/);
     assert.throws(function () {fn([], 'foo')}, /TypeError: Too many arguments in function unnamed \(expected: 1, actual: 2\)/);
   });
 

--- a/test/any_type.test.js
+++ b/test/any_type.test.js
@@ -120,4 +120,22 @@ describe('any type', function () {
     assert.throws(function () {fn()}, /TypeError: Too few arguments in function unnamed \(expected: Array or any, index: 0\)/);
   });
 
+  it('should permit multi-layered use of any', function() {
+    var fn = typed({
+      'any,any': function () {
+        return 'two';
+      },
+      'number,number,string': function () {
+        return 'three';
+      },
+    });
+
+    assert(fn.signatures instanceof Object);
+    assert.strictEqual(Object.keys(fn.signatures).length, 2);
+    assert.equal(fn('a','b'), 'two');
+    assert.equal(fn(1,1), 'two');
+    assert.equal(fn(1,1,'a'), 'three');
+    assert.throws(function () {fn(1,1,1)}, /TypeError: Unexpected type of argument in function unnamed \(expected: string, actual: number, index: 2\)/);
+  });
+
 });

--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -141,7 +141,7 @@ describe('conversion', function () {
     assert.equal(sum(false, 2,3), 5);
   });
 
-  it('should add conversions to a function with variable arguments in a non-conflicting way', function() {
+  it('should correctly add overlapping conversions to a function with variable arguments', function() {
     var fn = typed({
       '...number': function (values) {
         assert(Array.isArray(values));
@@ -160,8 +160,8 @@ describe('conversion', function () {
     assert.equal(fn(2,3,4), 9);
     assert.equal(fn(false), 'boolean');
     assert.equal(fn(true), 'boolean');
-    assert.throws(function () {fn(2,true,4)}, /TypeError: Unexpected type of argument in function unnamed \(expected: number, actual: boolean, index: 1\)/);
-    assert.throws(function () {fn(true,2,4)}, /TypeError: Too many arguments in function unnamed \(expected: 1, actual: 3\)/);
+    assert.equal(fn(2,true,4), 7);
+    assert.equal(fn(true,2,4), 7);
   });
 
   it('should add conversions to a function with variable and union arguments', function() {
@@ -178,7 +178,7 @@ describe('conversion', function () {
     strictEqualArray(fn('str', true, false), ['str', 1, 0]);
     strictEqualArray(fn('str', 2, false), ['str', 2, 0]);
 
-    assert.throws(function () {fn(new Date(), '2')}, /TypeError: Unexpected type of argument in function unnamed \(expected: string or number, actual: Date, index: 0\)/)
+    assert.throws(function () {fn(new Date(), '2')}, /TypeError: Unexpected type of argument in function unnamed \(expected: number or string, actual: Date, index: 0\)/)
   });
 
   it('should add non-conflicting conversions to a function with one argument', function() {

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -70,7 +70,8 @@ describe('errors', function () {
     }, /Error: Signature "string" is defined twice/);
   });
 
-  it('should give correct error in case of conflicting union arguments (2)', function() {
+  // Note: error can be generated but breaks MathJS (conversions cause many conflicts)
+  it.skip('should give correct error in case of conflicting union arguments (2)', function() {
     assert.throws(function () {
       var fn = typed({
         '...string | number': function () {},

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -79,15 +79,6 @@ describe('errors', function () {
     }, /Error: Conflicting types "...string|number" and "...string"/);
   });
 
-  it('should give correct error in case of conflicting variable args', function() {
-    assert.throws(function () {
-      var fn = typed({
-        '...string': function () {},
-        'string': function () {}
-      });
-    }, /Error: Conflicting types "...string" and "string"/);
-  });
-
   it('should give correct error in case of wrong type of argument (varArgs)', function() {
     var fn = typed({'...number': function () {}});
 

--- a/test/variable_arguments.test.js
+++ b/test/variable_arguments.test.js
@@ -166,6 +166,17 @@ describe('variable arguments', function () {
     assert.equal(fn([],[]), 'two');
   });
 
+  it('should permit correct handling of overlapping varArgs', function() {
+    var fn = typed({
+      '...string': function () { return 'string'; },
+      'string, ...any': function () { return 'any'; }
+    });
+
+    assert.equal(fn('a'), 'string');
+    assert.equal(fn('a', 'a'), 'any'); // Note: edge case. Could be argued either way.
+    assert.equal(fn('a', 2), 'any');
+  });
+
   it('should give precedence to non-varArgs signature in case of overlap', function() {
     var fn = typed({
       '...string': function () { return 'many'; },

--- a/test/variable_arguments.test.js
+++ b/test/variable_arguments.test.js
@@ -166,4 +166,15 @@ describe('variable arguments', function () {
     assert.equal(fn([],[]), 'two');
   });
 
+  it('should give precedence to non-varArgs signature in case of overlap', function() {
+    var fn = typed({
+      '...string': function () { return 'many'; },
+      'string': function () { return 'one'; }
+    });
+
+    assert.equal(fn('a'),'one');
+    assert.equal(fn('a','a'),'many');
+    assert.throws(function() { fn(); }, /TypeError: Too few arguments in function unnamed \(expected: string, index: 0\)/);
+  });
+
 });

--- a/test/variable_arguments.test.js
+++ b/test/variable_arguments.test.js
@@ -149,4 +149,21 @@ describe('variable arguments', function () {
     }, /SyntaxError: Unexpected variable arguments operator "..."/);
   });
 
+  it('should correctly interact with any', function() {
+    var fn = typed({
+      'string': function () {
+        return 'one';
+      },
+      '...any': function () {
+        return 'two';
+      }
+    });
+
+    assert.equal(fn('a'), 'one');
+    assert.equal(fn([]), 'two');
+    assert.equal(fn('a','a'), 'two');
+    assert.equal(fn('a',[]), 'two');
+    assert.equal(fn([],[]), 'two');
+  });
+
 });

--- a/typed-function.js
+++ b/typed-function.js
@@ -936,13 +936,6 @@
             existing.signatures.push(signature);
           });
 
-        // check for overlapping varArgs signatures
-        if(param.varArgs) {
-          entries
-            .filter(function(entry) { return entry.param.varArgs && entry.param.overlapping(param); })
-            .forEach(function(entry) { throw new Error('Conflicting types "' + entry.param + '" and "' + param + '"'); });
-        }
-
         if(!found) {
           entries.push({
             param: param,

--- a/typed-function.js
+++ b/typed-function.js
@@ -719,8 +719,9 @@
         else {
           if (this.param.anyType) {
             // any type
-            code.push(prefix + '// type: any');
-            code.push(this._innerCode(refs, prefix));
+            code.push(prefix + 'if (arguments.length > ' + index + ') { // type: any');
+            code.push(this._innerCode(refs, prefix + '  '));
+            code.push(prefix + '}');
           }
           else {
             // regular type

--- a/typed-function.js
+++ b/typed-function.js
@@ -309,30 +309,30 @@
      * @param {Param} other
      * @return {Param} Returns a param representing the types in this param that are not in the other
      */
-	Param.prototype.except = function (other) {
-		var types = contains(this.types, 'any') ^ contains(other.types, 'any')
-			? contains(this.types, 'any') ? this.types : []
-			: this.types.filter(function(type) { return !contains(other.types, type); });
+    Param.prototype.except = function (other) {
+      var types = contains(this.types, 'any') ^ contains(other.types, 'any')
+        ? contains(this.types, 'any') ? this.types : []
+        : this.types.filter(function(type) { return !contains(other.types, type); });
 
-		return this.varArgs ^ other.varArgs
-			// varArgs trumps non-varArgs, filter only one-way
-			? new Param(this.varArgs ? this.types : types, this.varArgs)
-			// where both are equivalent, filter as normal
-			: new Param(types, this.varArgs);
-	};
+      return this.varArgs ^ other.varArgs
+        // varArgs trumps non-varArgs, filter only one-way
+        ? new Param(this.varArgs ? this.types : types, this.varArgs)
+        // where both are equivalent, filter as normal
+        : new Param(types, this.varArgs);
+    };
 
     /**
      * Return a new param based on the intersection of this param and another
      * @param {Param} other
      * @return {Param} Returns a param representing the common types to both
      */
- 	Param.prototype.intersect = function (other) {
- 	    // the intersection of 'any' is always the other param, or 'any' if both are wildcards.
- 	    var types = contains(this.types, 'any')
- 	        ? other.types
- 	        : this.types.filter(function(type) { return contains(other.types, 'any') || contains(other.types, type); })
-		return new Param(types, this.varArgs && other.varArgs);
-	};
+    Param.prototype.intersect = function (other) {
+      // the intersection of 'any' is always the other param, or 'any' if both are wildcards.
+      var types = contains(this.types, 'any')
+        ? other.types
+        : this.types.filter(function(type) { return contains(other.types, 'any') || contains(other.types, type); })
+      return new Param(types, this.varArgs && other.varArgs);
+    };
 
     /**
      * Create a clone of this param
@@ -947,20 +947,20 @@
         // group signatures with compatible params at current index
         var param = signature.params[index];
 
-		var remainder = param;
+        var remainder = param;
 
-		entries = entries.map(function(entry) {
-			remainder = remainder.except(entry.param);
-			return [{
-				param: entry.param.except(param),
-				signatures: entry.signatures
-			}, {
-				param: entry.param.intersect(param),
-				signatures: entry.signatures.concat(signature)
-			}];
-		}).reduce(function(a, b) { return a.concat(b); }, [])
-			.concat({ param: remainder, signatures: [signature] })
-			.filter(function(entry) { return entry.param.types.length; });
+        entries = entries.map(function(entry) {
+          remainder = remainder.except(entry.param);
+          return [{
+            param: entry.param.except(param),
+            signatures: entry.signatures
+          }, {
+            param: entry.param.intersect(param),
+            signatures: entry.signatures.concat(signature)
+          }];
+        }).reduce(function(a, b) { return a.concat(b); }, [])
+          .concat({ param: remainder, signatures: [signature] })
+          .filter(function(entry) { return entry.param.types.length; });
       }
 
       // parse the childs

--- a/typed-function.js
+++ b/typed-function.js
@@ -867,40 +867,6 @@
         return Signature.compare(a, b);
       });
 
-      // filter redundant conversions from signatures with varArgs
-      // TODO: simplify this loop or move it to a separate function
-      for (i = 0; i < signatures.length; i++) {
-        signature = signatures[i];
-
-        if (signature.varArgs) {
-          var index = signature.params.length - 1;
-          var param = signature.params[index];
-
-          var t = 0;
-          while (t < param.types.length) {
-            if (param.conversions[t]) {
-              var type = param.types[t];
-
-              for (var j = 0; j < signatures.length; j++) {
-                var other = signatures[j];
-                var p = other.params[index];
-
-                if (other !== signature &&
-                    p &&
-                    contains(p.types, type) && !p.conversions[index]) {
-                  // this (conversion) type already exists, remove it
-                  param.types.splice(t, 1);
-                  param.conversions.splice(t, 1);
-                  t--;
-                  break;
-                }
-              }
-            }
-            t++;
-          }
-        }
-      }
-
       return signatures;
     }
 

--- a/typed-function.js
+++ b/typed-function.js
@@ -694,28 +694,26 @@
               }
             }
 
-            code.push(prefix + 'if (' + getTests(allTypes, 'arg' + index) + ') { ' + comment);
-            code.push(prefix + '  var varArgs = [arg' + index + '];');
-            code.push(prefix + '  for (var i = ' + (index + 1) + '; i < arguments.length; i++) {');
-            code.push(prefix + '    if (' + getTests(exactTypes, 'arguments[i]') + ') {');
-            code.push(prefix + '      varArgs.push(arguments[i]);');
+            code.push(prefix + 'var varArgs = [arg' + index + '];');
+            code.push(prefix + 'for (var i = ' + (index + 1) + '; i < arguments.length; i++) {');
+            code.push(prefix + '  if (' + getTests(exactTypes, 'arguments[i]') + ') {');
+            code.push(prefix + '    varArgs.push(arguments[i]);');
 
             for (var i = 0; i < allTypes.length; i++) {
               var conversion_i = this.param.conversions[i];
               if (conversion_i) {
                 var test = refs.add(getTypeTest(allTypes[i]), 'test');
                 var convert = refs.add(conversion_i.convert, 'convert');
-                code.push(prefix + '    }');
-                code.push(prefix + '    else if (' + test + '(arguments[i])) {');
-                code.push(prefix + '      varArgs.push(' + convert + '(arguments[i]));');
+                code.push(prefix + '  }');
+                code.push(prefix + '  else if (' + test + '(arguments[i])) {');
+                code.push(prefix + '    varArgs.push(' + convert + '(arguments[i]));');
               }
             }
-            code.push(prefix + '    } else {');
-            code.push(prefix + '      throw createError(name, arguments.length, i, arguments[i], \'' + exactTypes.join(',') + '\');');
-            code.push(prefix + '    }');
+            code.push(prefix + '  } else {');
+            code.push(prefix + '    throw createError(name, arguments.length, i, arguments[i], \'' + exactTypes.join(',') + '\');');
             code.push(prefix + '  }');
-            code.push(this.signature.toCode(refs, prefix + '  '));
             code.push(prefix + '}');
+            code.push(this.signature.toCode(refs, prefix));
           }
         }
         else {

--- a/typed-function.js
+++ b/typed-function.js
@@ -938,6 +938,13 @@
             existing.signatures.push(signature);
           });
 
+        // check for overlapping varArgs signatures
+        if(param.varArgs) {
+          entries
+            .filter(function(entry) { return entry.param.varArgs && entry.param.overlapping(param); })
+            .forEach(function(entry) { throw new Error('Conflicting types "' + entry.param + '" and "' + param + '"'); });
+        }
+
         if(!found) {
           entries.push({
             param: param,

--- a/typed-function.js
+++ b/typed-function.js
@@ -661,13 +661,11 @@
           var varIndex = this.signature.params.length - 2;
           if (this.param.anyType) {
             // variable arguments with any type
-            code.push(prefix + 'if (arguments.length > ' + index + ') {');
-            code.push(prefix + '  var varArgs = [];');
-            code.push(prefix + '  for (var i = ' + varIndex + '; i < arguments.length; i++) {');
-            code.push(prefix + '    varArgs.push(arguments[i]);');
-            code.push(prefix + '  }');
-            code.push(this.signature.toCode(refs, prefix + '  '));
+            code.push(prefix + 'var varArgs = [];');
+            code.push(prefix + 'for (var i = ' + varIndex + '; i < arguments.length; i++) {');
+            code.push(prefix + '  varArgs.push(arguments[i]);');
             code.push(prefix + '}');
+            code.push(this.signature.toCode(refs, prefix));
           }
           else {
             // variable arguments with a fixed type
@@ -965,6 +963,11 @@
       for (i = 0; i < entries.length; i++) {
         var entry = entries[i];
         childs[i] = parseTree(entry.signatures, path.concat(entry.param))
+      }
+
+      // don't bother with a varArgs node signature if there are no non-varArgs children
+      if(nodeSignature && nodeSignature.varArgs && childs[0] && childs[0].param.varArgs) {
+        nodeSignature = undefined;
       }
 
       return new Node(path, nodeSignature, childs);

--- a/typed-function.js
+++ b/typed-function.js
@@ -433,11 +433,13 @@
       var signatures = [];
 
       function recurse(signature, path) {
-        if (path.length < signature.params.length) {
+        if (path.length < signature.params.length + (signature.varArgs ? 1 : 0)) {
           var i, newParam, conversion;
 
-          var param = signature.params[path.length];
-          if (param.varArgs) {
+          var param = signature.getParam(path.length);
+
+          // treat varArgs as two params; one obligatory, and the remainder optional
+          if (param.varArgs && path.length === signature.params.length) {
             // a variable argument. do not split the types in the parameter
             newParam = param.clone();
 
@@ -488,15 +490,7 @@
      */
     Signature.prototype.getParam = function(index) {
       // retrieve the specified parameter or the last parameter if varArgs has been specified
-      var param = this.params[index] || (this.varArgs && this.params[this.params.length - 1]) || undefined;
-
-      // for the special case of the first varArgs argument, duplicate but set varArgs to false
-      if(param && param.varArgs && index === this.params.length - 1) {
-        param = param.clone();
-        param.varArgs = false;
-      }
-
-      return param;
+      return this.params[index] || (this.varArgs && this.params[this.params.length - 1]) || undefined;
     };
 
     /**

--- a/typed-function.js
+++ b/typed-function.js
@@ -617,7 +617,7 @@
 
       var ref = this.fn ? refs.add(this.fn, 'signature') : undefined;
       if (ref) {
-        return prefix + 'return ' + ref + '(' + args.join(', ') + '); // Signature: ' + params.join(', ');
+        return prefix + 'return ' + ref + '(' + args.join(', ') + '); // signature: ' + params.join(', ');
       }
 
       return code.join('\n');

--- a/typed-function.js
+++ b/typed-function.js
@@ -247,8 +247,8 @@
      */
     Param.compare = function (a, b) {
       // TODO: simplify parameter comparison, it's a mess
-      if (a.anyType) return 1;
-      if (b.anyType) return -1;
+      if(a.varArgs ^ b.varArgs) return a.varArgs ? 1 : -1;
+      if(a.anyType ^ b.anyType) return a.anyType ? 1 : -1;
 
       if (contains(a.types, 'Object')) return 1;
       if (contains(b.types, 'Object')) return -1;


### PR DESCRIPTION
This particular case wasn't covered by any tests in typed-function for it so it slipped past. See first commit for the failing case.

This PR is a WIP for now, just to let you know this is why there's a failing math.mode test in mathjs... Should be finished tomorrow. Last part should be fixing the call signature for varArgs sigs in Node.toCode. Sorry!
