### PR TITLE
Support recursive calls that respect merged functions

### DIFF
--- a/examples/recursion.js
+++ b/examples/recursion.js
@@ -1,0 +1,14 @@
+var typed = require('../typed-function');
+
+// create a typed function that invokes itself
+var sqrt = typed({
+  'number': function (value) {
+    return Math.sqrt(value);
+  },
+  'string': function (value) {
+    return this.call(parseInt(value, 10));
+  }
+});
+
+// use the typed function
+console.log(sqrt(9));         // output: 3

--- a/examples/recursion.js
+++ b/examples/recursion.js
@@ -6,9 +6,9 @@ var sqrt = typed({
     return Math.sqrt(value);
   },
   'string': function (value) {
-    return this.call(parseInt(value, 10));
+    return this(parseInt(value, 10));
   }
 });
 
 // use the typed function
-console.log(sqrt(9));         // output: 3
+console.log(sqrt("9"));         // output: 3

--- a/test/construction.test.js
+++ b/test/construction.test.js
@@ -361,11 +361,11 @@ describe('construction', function() {
         return 'number:' + value;
       },
       'string': function (value) {
-        return this.call(parseInt(value, 10));
+        return this(parseInt(value, 10));
       }
     });
 
-    assert.equal(fn('2'), 'number:2')
+    assert.equal(fn('2'), 'number:2');
   })
 
 });

--- a/test/construction.test.js
+++ b/test/construction.test.js
@@ -355,4 +355,17 @@ describe('construction', function() {
         ['number', 'string', 'boolean']);
   });
 
+  it('should allow a function to be defined recursively', function () {
+    var fn = typed({
+      'number': function (value) {
+        return 'number:' + value;
+      },
+      'string': function (value) {
+        return this.call(parseInt(value, 10));
+      }
+    });
+
+    assert.equal(fn('2'), 'number:2')
+  })
+
 });

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -88,4 +88,31 @@ describe('merge', function () {
     var typed4 = typed(typed2, typed3);
     assert.equal(typed4.name, 'fn2');
   });
+
+  it('should allow recursive across merged signatures', function () {
+    var fn1 = typed({
+      '...number': function (values) {
+        var sum = 0;
+        for (var i = 0; i < values.length; i++) {
+          sum += values[i];
+        }
+        return sum;
+      }
+    });
+
+    var fn2 = typed({
+      '...string': function (values) {
+        var newValues = [];
+        for (var i = 0; i < values.length; i++) {
+          newValues[i] = parseInt(values[i], 10);
+        }
+        return this.apply(newValues);
+      }
+    });
+
+    var fn3 = typed(fn1, fn2);
+
+    assert.equal(fn3('1', '2', '3'), '6');
+    assert.equal(fn3(1, 2, 3), 6);
+  })
 });

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -106,7 +106,7 @@ describe('merge', function () {
         for (var i = 0; i < values.length; i++) {
           newValues[i] = parseInt(values[i], 10);
         }
-        return this.apply(newValues);
+        return this.apply(null, newValues);
       }
     });
 

--- a/typed-function.js
+++ b/typed-function.js
@@ -750,8 +750,23 @@
      * @param {function} fn
      * @return {function} Returns a wrapped function
      */
-    function compileArgsPreprocessing(params, fn) {
-      var fnConvert = fn;
+    function compileArgsPreprocessing(params, fn, resolveSelf) {
+      var baseFn = function() {
+        var self = resolveSelf();
+
+        var proxy = {
+          call: function() {
+            return self.apply(null, arguments);
+          },
+          apply: function(args) {
+            return self.apply(null, arguments[0]);
+          }
+        }
+
+        return fn.apply(proxy, arguments);
+      }
+
+      var fnConvert = baseFn;
 
       // TODO: can we make this wrapper function smarter/simpler?
 
@@ -769,7 +784,7 @@
             args[last] = arguments[last].map(compiledConversions[last]);
           }
 
-          return fn.apply(null, args);
+          return baseFn.apply(null, args);
         }
       }
 
@@ -1043,9 +1058,15 @@
       var test41 = ok4 ? compileTest(signatures[4].params[1]) : notOk;
       var test51 = ok5 ? compileTest(signatures[5].params[1]) : notOk;
 
+      var fn
+
+      function resolveSelf() {
+        return fn
+      }
+
       // compile the functions
       var fns = signatures.map(function(signature) {
-        return compileArgsPreprocessing(signature.params, signature.fn)
+        return compileArgsPreprocessing(signature.params, signature.fn, resolveSelf)
       });
 
       var fn0 = ok0 ? fns[0] : undef;
@@ -1079,7 +1100,7 @@
 
       // create the typed function
       // fast, specialized version. Falls back to the slower, generic one if needed
-      var fn = function fn(arg0, arg1) {
+      fn = function fn(arg0, arg1) {
         'use strict';
 
         if (arguments.length === len0 && test00(arg0) && test01(arg1)) { return fn0.apply(null, arguments); }

--- a/typed-function.js
+++ b/typed-function.js
@@ -1079,24 +1079,18 @@
 
       // create the typed function
       // fast, specialized version. Falls back to the slower, generic one if needed
-      var makeFn = function () {
-        var fn = function fn(arg0, arg1) {
-          'use strict';
+      var fn = function fn(arg0, arg1) {
+        'use strict';
 
-          if (arguments.length === len0 && test00(arg0) && test01(arg1)) { return fn0.apply(fn, arguments); }
-          if (arguments.length === len1 && test10(arg0) && test11(arg1)) { return fn1.apply(fn, arguments); }
-          if (arguments.length === len2 && test20(arg0) && test21(arg1)) { return fn2.apply(fn, arguments); }
-          if (arguments.length === len3 && test30(arg0) && test31(arg1)) { return fn3.apply(fn, arguments); }
-          if (arguments.length === len4 && test40(arg0) && test41(arg1)) { return fn4.apply(fn, arguments); }
-          if (arguments.length === len5 && test50(arg0) && test51(arg1)) { return fn5.apply(fn, arguments); }
+        if (arguments.length === len0 && test00(arg0) && test01(arg1)) { return fn0.apply(fn, arguments); }
+        if (arguments.length === len1 && test10(arg0) && test11(arg1)) { return fn1.apply(fn, arguments); }
+        if (arguments.length === len2 && test20(arg0) && test21(arg1)) { return fn2.apply(fn, arguments); }
+        if (arguments.length === len3 && test30(arg0) && test31(arg1)) { return fn3.apply(fn, arguments); }
+        if (arguments.length === len4 && test40(arg0) && test41(arg1)) { return fn4.apply(fn, arguments); }
+        if (arguments.length === len5 && test50(arg0) && test51(arg1)) { return fn5.apply(fn, arguments); }
 
-          return generic.apply(fn, arguments);
-        }
-
-        return fn;
+        return generic.apply(fn, arguments);
       }
-
-      var fn = makeFn();
 
       // attach name the typed function
       try {

--- a/typed-function.js
+++ b/typed-function.js
@@ -751,22 +751,11 @@
      * @return {function} Returns a wrapped function
      */
     function compileArgsPreprocessing(params, fn, resolveSelf) {
-      var baseFn = function() {
-        var self = resolveSelf();
-
-        var proxy = {
-          call: function() {
-            return self.apply(null, arguments);
-          },
-          apply: function(args) {
-            return self.apply(null, arguments[0]);
-          }
-        }
-
-        return fn.apply(proxy, arguments);
+      function fnResolveSelf() {
+        return fn.apply(resolveSelf(), arguments);
       }
 
-      var fnConvert = baseFn;
+      var fnConvert = fnResolveSelf;
 
       // TODO: can we make this wrapper function smarter/simpler?
 
@@ -784,7 +773,7 @@
             args[last] = arguments[last].map(compiledConversions[last]);
           }
 
-          return baseFn.apply(null, args);
+          return fnResolveSelf.apply(null, args);
         }
       }
 
@@ -1058,15 +1047,15 @@
       var test41 = ok4 ? compileTest(signatures[4].params[1]) : notOk;
       var test51 = ok5 ? compileTest(signatures[5].params[1]) : notOk;
 
-      var fn
+      var fn;
 
       function resolveSelf() {
-        return fn
+        return fn;
       }
 
       // compile the functions
       var fns = signatures.map(function(signature) {
-        return compileArgsPreprocessing(signature.params, signature.fn, resolveSelf)
+        return compileArgsPreprocessing(signature.params, signature.fn, resolveSelf);
       });
 
       var fn0 = ok0 ? fns[0] : undef;


### PR DESCRIPTION
This PR implements a method of recursion that works with merged typed-functions.  The issue was originally discussed here: https://github.com/josdejong/mathjs/issues/1885.

I tested this change against math.js, replacing all recursive typed-function calls I could find in the library, and the tests are passing.  I can open a PR for that too, if this looks acceptable.

A slight modification on this approach would be to remove the proxy object and change 

```
return fn.apply(proxy, arguments);
```

to

```
return fn.apply(self, arguments);
```

which would then allow definitions like so:

```
var sqrt = typed({
  'number': function (value) {
    return Math.sqrt(value);
  },
  'string': function (value) {
    return this(parseInt(value, 10));
  }
});
```

However, I am not sure if using a function bound as `this` works in all browsers.

