### PR TITLE
Add handler for typed function signature mismatch

### DIFF
--- a/test/onMismatch.test.js
+++ b/test/onMismatch.test.js
@@ -1,0 +1,40 @@
+var assert = require('assert');
+var typed = require('../typed-function');
+
+describe('onMismatch handler', () => {
+  const square = typed('square', {
+    number: x => x*x,
+    string: s => s + s
+  })
+
+  it('should replace the return value of a mismatched call', () => {
+    typed.onMismatch = () => 42
+    assert.strictEqual(square(5), 25)
+    assert.strictEqual(square('yo'), 'yoyo')
+    assert.strictEqual(square([13]), 42)
+  })
+
+  const myErrorLog = []
+  it('should allow error logging', () => {
+    typed.onMismatch = (name, args, signatures) => {
+      myErrorLog.push(typed.createError(name, args, signatures))
+      return null
+    }
+    square({the: 'circle'})
+    square(7)
+    square('me')
+    square(1,2)
+    assert.strictEqual(myErrorLog.length, 2)
+    assert('data' in myErrorLog[0])
+  })
+
+  it('should allow changing the error', () => {
+    typed.onMismatch = name => { throw Error('Problem with ' + name) }
+    assert.throws(() => square(['one']), /Problem with square/)
+  })
+
+  it('should allow a return to standard behavior', () => {
+    typed.onMismatch = typed.throwMismatchError
+    assert.throws(() => square('be', 'there'), TypeError)
+  })
+})

--- a/typed-function.js
+++ b/typed-function.js
@@ -1355,6 +1355,8 @@
     typed.conversions = _conversions;
     typed.ignore = _ignore;
     typed.onMismatch = _onMismatch;
+    typed.throwMismatchError = _onMismatch;
+    typed.createError = createError;
     typed.convert = convert;
     typed.find = find;
 

--- a/typed-function.js
+++ b/typed-function.js
@@ -1074,7 +1074,7 @@
           }
         }
 
-        throw createError(name, arguments, signatures);
+        return typed.onMismatch(name, arguments, signatures);
       }
 
       // create the typed function
@@ -1106,6 +1106,16 @@
       fn.signatures = createSignaturesMap(signatures);
 
       return fn;
+    }
+
+    /**
+     * Action to take on mismatch
+     * @param {string} name      Name of function that was attempted to be called
+     * @param {Array} args       Actual arguments to the call
+     * @param {Array} signatures Known signatures of the named typed-function
+     */
+    function _onMismatch(name, args, signatures) {
+      throw createError(name, args, signatures);
     }
 
     /**
@@ -1344,6 +1354,7 @@
     typed.types = _types;
     typed.conversions = _conversions;
     typed.ignore = _ignore;
+    typed.onMismatch = _onMismatch;
     typed.convert = convert;
     typed.find = find;
 


### PR DESCRIPTION
This way a client can implement custom behavior in the situation that a typed function call does not match any of its signatures. One specific application is to enable symbolic computation in mathjs (see demo PR to come momentarily).

This is not currently recommended for merging, although if the feature is of interest it's close: it would just need documentation, tests, and likely it would be good to expose `createError` as well for potential use in a client's `onMismatch` handler.