### PR TITLE
Fix #128: handle conversion of a value which has multiple matching types correctly (WIP)

### DIFF
--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -30,7 +30,7 @@ describe('convert', function () {
     assert.strictEqual(typed.convert(true, 'string'), 'true');
     assert.strictEqual(typed.convert(true, 'number'), 1);
   });
-  
+
   it('should return same value when conversion is not needed', function () {
     assert.strictEqual(typed.convert(2, 'number'), 2);
     assert.strictEqual(typed.convert(true, 'boolean'), true);
@@ -39,4 +39,38 @@ describe('convert', function () {
   it('should throw an error when no conversion function is found', function() {
     assert.throws(function () {typed.convert(2, 'boolean')}, /Error: Cannot convert from number to boolean/);
   });
+
+  it('should pick the right conversion function when a value matches multiple types', () => {
+    // based on https://github.com/josdejong/typed-function/issues/128
+    const typed2 = typed.create()
+
+    typed2.types = [
+      {
+        name: 'number',
+        test: x => typeof x === 'number'
+      },
+      {
+        name: 'identifier',
+        test: x => (typeof x === 'string' &&
+          /^\p{Alphabetic}[\d\p{Alphabetic}]*$/u.test(x))
+      },
+      {
+        name: 'string',
+        test: x => typeof x === 'string'
+      }
+    ]
+
+    typed2.addConversion({ from: 'string', to: 'number', convert: x => parseFloat(x) })
+
+    const check = typed2('check', {
+      identifier: i => 'found an identifier: ' + i,
+      string: s => s + ' is just a string'
+    })
+
+    assert.strictEqual(check('xy33'), 'found an identifier: xy33')
+    assert.strictEqual(check('Wow!'), 'Wow! is just a string')
+
+    assert.strictEqual(typed2.convert('123.5', 'number'), 123.5)
+    assert.strictEqual(typed2.convert('Infinity', 'number'), Infinity)
+  })
 });

--- a/typed-function.js
+++ b/typed-function.js
@@ -556,7 +556,7 @@
 
             err = new TypeError('Unexpected type of argument in function ' + _name +
                 ' (expected: ' + expected.join(' or ') +
-                ', actual: ' + actualTypes.join(' or ') + ', index: ' + index + ')');
+                ', actual: ' + actualTypes.join(' & ') + ', index: ' + index + ')');
             err.data = {
               category: 'wrongType',
               fn: _name,

--- a/typed-function.js
+++ b/typed-function.js
@@ -142,24 +142,6 @@
     }
 
     /**
-     * Find a type that matches a value.
-     * @param {*} value
-     * @return {string} Returns the name of the first type for which
-     *                  the type test matches the value.
-     */
-    function findTypeName(value) {
-      var entry = findInArray(typed.types, function (entry) {
-        return entry.test(value);
-      });
-
-      if (entry) {
-        return entry.name;
-      }
-
-      throw new TypeError('Value has unknown type. Value: ' + value);
-    }
-
-    /**
      * Find all types that match the value.
      * @param {*} value
      * @return {{[string]: boolean}} Returns a map with the names of the
@@ -570,16 +552,16 @@
           // no matching signatures anymore, throw error "wrong type"
           expected = mergeExpectedParams(matchingSignatures, index);
           if (expected.length > 0) {
-            var actualType = findTypeName(args[index]);
+            var actualTypes = Object.keys(findTypeNames(args[index]));
 
             err = new TypeError('Unexpected type of argument in function ' + _name +
                 ' (expected: ' + expected.join(' or ') +
-                ', actual: ' + actualType + ', index: ' + index + ')');
+                ', actual: ' + actualTypes.join(' or ') + ', index: ' + index + ')');
             err.data = {
               category: 'wrongType',
               fn: _name,
               index: index,
-              actual: actualType,
+              actual: actualTypes,
               expected: expected
             }
             return err;
@@ -626,7 +608,7 @@
           '" do not match any of the defined signatures of function ' + _name + '.');
       err.data = {
         category: 'mismatch',
-        actual: args.map(findTypeName)
+        actual: flatMap(args, arg => Object.keys(findTypeNames(arg)))
       }
       return err;
     }

--- a/typed-function.js
+++ b/typed-function.js
@@ -160,6 +160,25 @@
     }
 
     /**
+     * Find all types that match the value.
+     * @param {*} value
+     * @return {{[string]: boolean}} Returns a map with the names of the
+     *                               matching types as key and true as value
+     */
+    function findTypeNames(value) {
+      const typeNames = {}
+
+      for (let i = 0; i < typed.types.length; i++) {
+        const entry = typed.types[i]
+        if (entry.test(value)) {
+          typeNames[entry.name] = true
+        }
+      }
+
+      return typeNames
+    }
+
+    /**
      * Find a specific signature from a (composed) typed function, for example:
      *
      *   typed.find(fn, ['number', 'string'])
@@ -213,23 +232,24 @@
      * @param {string} type
      */
     function convert (value, type) {
-      var from = findTypeName(value);
+      var valueTypesMap = findTypeNames(value);
 
-      // check conversion is needed
-      if (type === from) {
+      // check whether conversion is needed
+      if (valueTypesMap[type] === true) {
         return value;
       }
 
       for (var i = 0; i < typed.conversions.length; i++) {
         var conversion = typed.conversions[i];
-        if (conversion.from === from && conversion.to === type) {
+        if (valueTypesMap[conversion.from] === true && conversion.to === type) {
           return conversion.convert(value);
         }
       }
 
-      throw new Error('Cannot convert from ' + from + ' to ' + type);
+      throw new Error('Cannot convert from ' +
+        Object.keys(valueTypesMap).join(' or ') + ' to ' + type);
     }
-    
+
     /**
      * Stringify parameters in a normalized way
      * @param {Param[]} params

--- a/typed-function.js
+++ b/typed-function.js
@@ -608,7 +608,7 @@
           '" do not match any of the defined signatures of function ' + _name + '.');
       err.data = {
         category: 'mismatch',
-        actual: flatMap(args, arg => Object.keys(findTypeNames(arg)))
+        actual: args.map(arg => Object.keys(findTypeNames(arg)))
       }
       return err;
     }


### PR DESCRIPTION
This is a possible fix for #128 

This PR replaces `findTypeName` (finding the first match) with `findTypeNames` (returning all matching types).

This is currently a WIP, needs more discussion on whether this is the right approach.