### PR TITLE
fix(compareSignatures): prefer conversion to any

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,37 @@ The following type expressions are supported:
 - Variable arguments: `...number`
 - Any type: `any`
 
+### Dispatch
+
+When a typed function is called, an implementation with a matching signature
+is called, where conversions may be applied to actual arguments in order to
+find a match.
+
+Among all matching signatures, the one to execute is chosen by the following
+preferences, in order of priority:
+
+* one that does not have an `...any` parameter
+* one with the fewest `any` parameters
+* one that does not use conversions to match a rest parameter
+* one with the fewest conversions needed to match overall
+* one with no rest parameter
+* If there's a rest parameter, the one with the most non-rest parameters
+* The one with the largest number of preferred parameters
+* The one with the earliest preferred parameter
+
+When this process gets to the point of comparing individual parameters,
+the preference between parameters is determined by the following, in
+priority order:
+
+* All specific types are preferred to the 'any' type
+* All directly matching types are preferred to conversions
+* Types earlier in the list of known types are preferred
+* Among conversions, ones earlier in the list are preferred
+
+If none of these aspects produces a preference, then in those contexts in
+which Array.sort is stable, the order implementations were listed when
+the typed-function was created breaks the tie. Otherwise the dispatch may
+select any of the "tied" implementations.
 
 ## API
 

--- a/test/any_type.test.js
+++ b/test/any_type.test.js
@@ -76,7 +76,7 @@ describe('any type', function () {
     });
 
     assert(fn.signatures instanceof Object);
-    assert.deepEqual(Object.keys(fn.signatures), ['string,any', 'any']);
+    assert.deepEqual(Object.keys(fn.signatures), ['any', 'string,any']);
     assert.equal(fn('foo', 2), 'string,any');
     assert.equal(fn([]), 'any');
     assert.equal(fn('foo'), 'any');

--- a/test/compose.test.js
+++ b/test/compose.test.js
@@ -16,7 +16,7 @@ describe('compose', function () {
     assert.equal(fn(false, 2), 'B');
     assert.equal(fn('str'), 'C');
     // FIXME: should return correct error message
-    assert.throws(function () {fn()},           /TypeError: Too few arguments in function unnamed \(expected: number or string or boolean, index: 0\)/);
+    assert.throws(function () {fn()},           /TypeError: Too few arguments in function unnamed \(expected: string or number or boolean, index: 0\)/);
     assert.throws(function () {fn(1,2,3)},      /TypeError: Unexpected type of argument in function unnamed \(expected: boolean, actual: number, index: 1\)/);
     assert.throws(function () {fn('str', 2)},   /TypeError: Unexpected type of argument in function unnamed \(expected: boolean, actual: number, index: 1\)/);
     assert.throws(function () {fn(true, 'str')},/TypeError: Unexpected type of argument in function unnamed \(expected: number or boolean, actual: string, index: 1\)/);

--- a/test/compose.test.js
+++ b/test/compose.test.js
@@ -15,7 +15,6 @@ describe('compose', function () {
     assert.equal(fn(false, true), 'B');
     assert.equal(fn(false, 2), 'B');
     assert.equal(fn('str'), 'C');
-    // FIXME: should return correct error message
     assert.throws(function () {fn()},           /TypeError: Too few arguments in function unnamed \(expected: string or number or boolean, index: 0\)/);
     assert.throws(function () {fn(1,2,3)},      /TypeError: Unexpected type of argument in function unnamed \(expected: boolean, actual: number, index: 1\)/);
     assert.throws(function () {fn('str', 2)},   /TypeError: Unexpected type of argument in function unnamed \(expected: boolean, actual: number, index: 1\)/);

--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -293,7 +293,7 @@ describe('conversion', function () {
     assert.equal(fn(2, 4, 5), 'numbers');
   });
 
-  it('should not apply conversions when having an any type argument', function() {
+  it('should prefer conversions to any type argument', function() {
     var fn = typed({
       'number': function (a) {
         return 'number';
@@ -304,7 +304,7 @@ describe('conversion', function () {
     });
 
     assert.equal(fn(2), 'number');
-    assert.equal(fn(true), 'any');
+    assert.equal(fn(true), 'number');
     assert.equal(fn('foo'), 'any');
     assert.equal(fn('{}'), 'any');
   });


### PR DESCRIPTION
  This is a proposal for a revised order of dispatch of typed-function
  calls. The only changes are to the ordering of params and signatures
  implicit in the functions `compareParams` and `compareSignatures`. The
  details of the new ordering are described in the README.

  Resolves #14.