### PR TITLE
Option A: keep functions unbound, replace `this` with `typed.self` (WIP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ A typed function can be constructed in two ways:
 
 ### Recursion
 
-The `this` keyword can be used to self-reference the typed-function:
+The `typed.self` keyword can be used to self-reference the currently invoked typed-function:
 
 ```js
 var sqrt = typed({
@@ -401,13 +401,17 @@ var sqrt = typed({
   },
   'string': function (value) {
     // on the following line we self reference the typed-function using "this"
-    return this(parseInt(value, 10));
+    return typed.self(parseInt(value, 10));
   }
 });
 
 // use the typed function
 console.log(sqrt('9')); // output: 3
 ```
+
+> Note that for performance reasons, `typed.self` is not cleaned up after the 
+function call. So when used from outside a function call, it contains the last
+invoked function. This shouldn't be used though.
 
 
 ### Output

--- a/test/construction.test.js
+++ b/test/construction.test.js
@@ -361,11 +361,27 @@ describe('construction', function() {
         return 'number:' + value;
       },
       'string': function (value) {
-        return this(parseInt(value, 10));
+        return typed.self(parseInt(value, 10));
       }
     });
 
     assert.equal(fn('2'), 'number:2');
-  })
+  });
 
+  it('should pass this function context', () => {
+    var getProperty = typed('getProperty', {
+      'string': function (key) {
+        return this[key]
+      }
+    })
+
+    assert.equal(getProperty('value'), undefined)
+
+    var obj = {
+      value: 42,
+      getProperty
+    }
+
+    assert.equal(obj.getProperty('value'), 42)
+  })
 });

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -106,7 +106,7 @@ describe('merge', function () {
         for (var i = 0; i < values.length; i++) {
           newValues[i] = parseInt(values[i], 10);
         }
-        return this.apply(null, newValues);
+        return typed.self.apply(null, newValues);
       }
     });
 

--- a/typed-function.js
+++ b/typed-function.js
@@ -229,7 +229,7 @@
 
       throw new Error('Cannot convert from ' + from + ' to ' + type);
     }
-    
+
     /**
      * Stringify parameters in a normalized way
      * @param {Param[]} params
@@ -1082,14 +1082,18 @@
       var fn = function fn(arg0, arg1) {
         'use strict';
 
-        if (arguments.length === len0 && test00(arg0) && test01(arg1)) { return fn0.apply(fn, arguments); }
-        if (arguments.length === len1 && test10(arg0) && test11(arg1)) { return fn1.apply(fn, arguments); }
-        if (arguments.length === len2 && test20(arg0) && test21(arg1)) { return fn2.apply(fn, arguments); }
-        if (arguments.length === len3 && test30(arg0) && test31(arg1)) { return fn3.apply(fn, arguments); }
-        if (arguments.length === len4 && test40(arg0) && test41(arg1)) { return fn4.apply(fn, arguments); }
-        if (arguments.length === len5 && test50(arg0) && test51(arg1)) { return fn5.apply(fn, arguments); }
+        // self contains the latest called function
+        // this is a bit dirty (should be cleaned up afterwards)
+        typed.self = fn;
 
-        return generic.apply(fn, arguments);
+        if (arguments.length === len0 && test00(arg0) && test01(arg1)) { return fn0.apply(this, arguments); }
+        if (arguments.length === len1 && test10(arg0) && test11(arg1)) { return fn1.apply(this, arguments); }
+        if (arguments.length === len2 && test20(arg0) && test21(arg1)) { return fn2.apply(this, arguments); }
+        if (arguments.length === len3 && test30(arg0) && test31(arg1)) { return fn3.apply(this, arguments); }
+        if (arguments.length === len4 && test40(arg0) && test41(arg1)) { return fn4.apply(this, arguments); }
+        if (arguments.length === len5 && test50(arg0) && test51(arg1)) { return fn5.apply(this, arguments); }
+
+        return generic.apply(this, arguments);
       }
 
       // attach name the typed function


### PR DESCRIPTION
Keep typed-functions unbound, so they can be bound to a context by the user. Replace `this` with `typed.self`.

See discussion in #126 for pros/cons