### PR TITLE
Option B: keep functions unbound, replace `this` with `typed.referTo(...)` and `typed.referToThis(...)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,49 +390,45 @@ A typed function can be constructed in two ways:
     console.log(lenOrNothing(57, 'varieties')) // Output: 0
     ```
 
-### Recursion
+-   `typed.referTo(...string, callback: (resolvedFunctions: ...function) => function)`
 
-The `typed.reference((resolve: (signature: string) => string, self: function) => function)` function can be used to self-reference the typed-function itself. The most efficient way is to resolve the signature that you need at creation time:
+    Resolve references to one or multiple signatures of the typed-function itself. This looks like:
 
-```js
-var sqrt = typed({
-  'number': function (value) {
-    return Math.sqrt(value);
-  },
-  'string': typed.reference(function (resolve, self) {
-    // resolve a specific signature at creation time (most optimal for runtime performance)
-    const sqrtNumber = resolve('number')
-    
-    return function (value) {
-      return sqrtNumber(parseInt(value, 10));
-    }
-  })
-});
+    ```
+    typed.referTo(signature1, signature2, ..., function callback(fn1, fn2, ...) {
+      // ... use the resolved signatures fn1, fn2, ...
+    }) 
+    ```
 
-// use the typed function
-console.log(sqrt('9')); // output: 3
-```
+    Example usage:
+ 
+    ```js
+    const fn = typed({
+      'number': function (value) {
+        return 'Input was a number: ' + value;
+      },
+      'boolean': function (value) {
+        return 'Input was a boolean: ' + value;
+      },
+      'string': typed.referTo('number', 'boolean', (fnNumber, fnBoolean) => {
+        return function fnString(value) {
+          // here we use one of the other signatures of the typed-function directly:
+          return fnNumber(parseInt(value, 10));
+        }
+      })
+    });
+    ```
 
-When the typed-function is needed as a whole, and you basically want to re-dispatch the whole function, you can use the `self` reference: 
+    See also `typed.referToSelf(callback)`.
 
-```js
-var sqrt = typed({
-  'number': function (value) {
-    return Math.sqrt(value);
-  },
-  'string': typed.reference(function (resolve, self) {
-    return function (value) {
-      // on the following line we self reference the typed-function
-      // here, `self` will reference to the same function instance as `var sqrt = ...`
-      // this will re-dispatch the whole function 
-      return self(parseInt(value, 10));
-    }
-  })
-});
+-   `typed.referToSelf(callback: (self) => function)`
 
-// use the typed function
-console.log(sqrt('9')); // output: 3
-```
+    Refer to the typed-function itself. This can be used for recursive calls.
+    Note that this will fully re-dispatch the typed-function, which gives 
+    overhead. If the signature that needs to be invoked is already know, please
+    use `typed.referTo(...)` instead for better performance.
+
+    > In `typed-function@2` it was possible to use `this(...)` to reference the typed-function itself. In `typed-function@v3`, is replaced with the `typed.referTo(...)` and `typed.referToSelf(...)` methods. Typed-functions are unbound in `typed-function@v3` and can be bound to another context if needed.
 
 
 ### Output

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ A typed function can be constructed in two ways:
     ```
     typed.referTo(signature1, signature2, ..., function callback(fn1, fn2, ...) {
       // ... use the resolved signatures fn1, fn2, ...
-    }) 
+    });
     ```
 
     Example usage:
@@ -412,7 +412,13 @@ A typed function can be constructed in two ways:
       },
       'string': typed.referTo('number', 'boolean', (fnNumber, fnBoolean) => {
         return function fnString(value) {
-          // here we use one of the other signatures of the typed-function directly:
+          // here we use the signatures of the typed-function directly:
+          if (value === 'true') {
+            return fnBoolean(true);
+          }
+          if (value === 'false') {
+            return fnBoolean(false);
+          }
           return fnNumber(parseInt(value, 10));
         }
       })

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ A typed function can be constructed in two ways:
           if (value === 'false') {
             return fnBoolean(false);
           }
-          return fnNumber(parseInt(value, 10));
+          return fnNumber(parseFloat(value));
         }
       })
     });
@@ -467,6 +467,9 @@ A typed function can be constructed in two ways:
 
     > In `typed-function@2` it was possible to use `this(...)` to reference the typed-function itself. In `typed-function@v3`, is replaced with the `typed.referTo(...)` and `typed.referToSelf(...)` methods. Typed-functions are unbound in `typed-function@v3` and can be bound to another context if needed.
 
+-   `typed.warnAgainstDeprecatedThis: boolean`
+
+    Since `typed-function` v3, self-referencing a typed function using `this(...)` or `this.signatures` has been deprecated and replaced with the functions `typed.referTo` and `typed.referToSelf`. By default, all function bodies will be scanned against this deprecated usage pattern and an error will be thrown when encountered. To disable this validation step, change this option to `false`.
 
 ### Output
 

--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ A typed function can be constructed in two ways:
 
 ### Recursion
 
-The `this` keyword can be used to self-reference the typed-function:
+The `typed.self` keyword can be used to self-reference the currently invoked typed-function:
 
 ```js
 var sqrt = typed({
@@ -401,13 +401,17 @@ var sqrt = typed({
   },
   'string': function (value) {
     // on the following line we self reference the typed-function using "this"
-    return this(parseInt(value, 10));
+    return typed.self(parseInt(value, 10));
   }
 });
 
 // use the typed function
 console.log(sqrt('9')); // output: 3
 ```
+
+> Note that for performance reasons, `typed.self` is not cleaned up after the 
+function call. So when used from outside a function call, it contains the last
+invoked function. This shouldn't be used though.
 
 
 ### Output

--- a/README.md
+++ b/README.md
@@ -392,26 +392,24 @@ A typed function can be constructed in two ways:
 
 ### Recursion
 
-The `typed.self` keyword can be used to self-reference the currently invoked typed-function:
+The `typed.reference` function can be used to self-reference the typed-function itself:
 
 ```js
 var sqrt = typed({
   'number': function (value) {
     return Math.sqrt(value);
   },
-  'string': function (value) {
-    // on the following line we self reference the typed-function using "this"
-    return typed.self(parseInt(value, 10));
-  }
+  'string': typed.reference(self => {
+    return function (value) {
+      // on the following line we self reference the typed-function
+      return self(parseInt(value, 10));
+    }
+  })
 });
 
 // use the typed function
 console.log(sqrt('9')); // output: 3
 ```
-
-> Note that for performance reasons, `typed.self` is not cleaned up after the 
-function call. So when used from outside a function call, it contains the last
-invoked function. This shouldn't be used though.
 
 
 ### Output

--- a/test/any_type.test.js
+++ b/test/any_type.test.js
@@ -76,7 +76,7 @@ describe('any type', function () {
     });
 
     assert(fn.signatures instanceof Object);
-    assert.deepEqual(Object.keys(fn.signatures), ['any', 'string,any']);
+    assert.deepEqual(Object.keys(fn.signatures), ['string,any', 'any']);
     assert.equal(fn('foo', 2), 'string,any');
     assert.equal(fn([]), 'any');
     assert.equal(fn('foo'), 'any');

--- a/test/construction.test.js
+++ b/test/construction.test.js
@@ -406,7 +406,7 @@ describe('construction', function() {
           }
         })
       });
-    }, /Cannot refer to signature "string": reference signature "number" not found/)
+    }, /Cannot resolve reference in signature "string": reference signature "number" not found/)
   })
 
   it('should throw an exception when a signature is not resolved with referTo', function () {
@@ -422,7 +422,7 @@ describe('construction', function() {
           return 'number:' + value;
         })
       });
-    }, /Cannot refer to signature "string": signature is referring to a signature "number" which is not yet resolved/)
+    }, /Cannot resolve reference in signature "string": signature is referring to a signature "number" which is not yet resolved/)
   })
 
   it('should throw an exception when a signature in referTo is not a string', function () {
@@ -496,5 +496,17 @@ describe('construction', function() {
 
     var boundGetProperty = getProperty.bind({ otherValue: 123 })
     assert.equal(boundGetProperty('otherValue'), 123)
+  })
+
+  it('test', () => {
+    const refer = typed({
+      'number|string': arg => 'wow: ' + arg,
+      'boolean': typed.referTo('number|string', refS => b => {
+        if (b) return refS('true that!')
+        return refS('no way...')
+      })
+    })
+
+    console.log(refer.signatures)
   })
 });

--- a/test/construction.test.js
+++ b/test/construction.test.js
@@ -372,7 +372,7 @@ describe('construction', function() {
     assert.equal(fn('2'), 'number:2');
   });
 
-  it('should allow to resolve function signatures with referTo', function () {
+  it('should allow to resolve multiple function signatures with referTo', function () {
     var fnNumber = function (value) {
       return 'number:' + value;
     }
@@ -395,6 +395,25 @@ describe('construction', function() {
     });
 
     assert.equal(fn('2'), 'number:2');
+  });
+
+  it('should resolve referTo signatures on the resolved signatures, not exact matches', function () {
+    var fnNumberOrBoolean = function (value) {
+      return 'number or boolean:' + value;
+    }
+
+    var fn = typed({
+      'number|boolean': fnNumberOrBoolean,
+      'string': typed.referTo('number', (fnNumberResolved) => {
+        assert.strictEqual(fnNumberResolved, fnNumberOrBoolean)
+
+        return function fnString(value) {
+          return fnNumberResolved(parseInt(value, 10));
+        }
+      })
+    });
+
+    assert.equal(fn('2'), 'number or boolean:2');
   });
 
   it('should throw an exception when a signature is not found with referTo', function () {
@@ -496,17 +515,5 @@ describe('construction', function() {
 
     var boundGetProperty = getProperty.bind({ otherValue: 123 })
     assert.equal(boundGetProperty('otherValue'), 123)
-  })
-
-  it('test', () => {
-    const refer = typed({
-      'number|string': arg => 'wow: ' + arg,
-      'boolean': typed.referTo('number|string', refS => b => {
-        if (b) return refS('true that!')
-        return refS('no way...')
-      })
-    })
-
-    console.log(refer.signatures)
-  })
+  });
 });

--- a/test/construction.test.js
+++ b/test/construction.test.js
@@ -360,16 +360,18 @@ describe('construction', function() {
       'number': function (value) {
         return 'number:' + value;
       },
-      'string': function (value) {
-        return typed.self(parseInt(value, 10));
-      }
+      'string': typed.reference((self) => {
+        return function (value) {
+          return self(parseInt(value, 10));
+        }
+      })
     });
 
     assert.equal(fn('2'), 'number:2');
   });
 
   it('should pass this function context', () => {
-    var getProperty = typed('getProperty', {
+    var getProperty = typed({
       'string': function (key) {
         return this[key]
       }
@@ -383,5 +385,8 @@ describe('construction', function() {
     }
 
     assert.equal(obj.getProperty('value'), 42)
+
+    var boundGetProperty = getProperty.bind({ otherValue: 123 })
+    assert.equal(boundGetProperty('otherValue'), 123)
   })
 });

--- a/test/construction.test.js
+++ b/test/construction.test.js
@@ -361,11 +361,27 @@ describe('construction', function() {
         return 'number:' + value;
       },
       'string': function (value) {
-        return this(parseInt(value, 10));
+        return typed.self(parseInt(value, 10));
       }
     });
 
     assert.equal(fn('2'), 'number:2');
-  })
+  });
 
+  it('should pass this function context', () => {
+    var getProperty = typed('getProperty', {
+      'string': function (key) {
+        return this[key]
+      }
+    })
+
+    assert.equal(getProperty('value'), undefined)
+
+    var obj = {
+      value: 42,
+      getProperty
+    }
+
+    assert.equal(obj.getProperty('value'), 42)
+  })
 });

--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -95,10 +95,6 @@ describe('conversion', function () {
     assert.equal(fn('foo', true), 'string, number');
     assert.equal(fn('foo', 2), 'string, number');
     assert.equal(fn('foo', 'foo'), 'string, string');
-    assert.deepEqual(Object.keys(fn.signatures), [
-      'string,number',
-      'string,string'
-    ]);
   });
 
   it('should add conversions to a function with rest parameters (1)', function() {
@@ -345,12 +341,6 @@ describe('conversion', function () {
       assert.equal(fn(2, 'foo'), 'strings');
       assert.equal(fn(true, 'foo'), 'strings');
       assert.equal(fn('foo', true), 'strings');
-
-      assert.deepEqual(Object.keys(fn.signatures), [
-        'number,number',
-        'string,string',
-        'boolean,boolean'
-      ]);
     });
 
     it('should select the signatures with the conversion with the lowest index (1)', function () {
@@ -370,10 +360,7 @@ describe('conversion', function () {
 
       assert.strictEqual(fn(true), 'true');
 
-      assert.deepEqual(Object.keys(fn.signatures), [
-        'number',
-        'string'
-      ]);
+      assert.deepEqual(Object.keys(fn.signatures).length, 2);
     });
 
     it('should select the signatures with the conversion with the lowest index (2)', function () {

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -101,7 +101,7 @@ describe('merge', function () {
     });
 
     var fn2 = typed({
-      '...string': typed.reference((self) => {
+      '...string': typed.reference((resolve, self) => {
         return function (values) {
           var newValues = [];
           for (var i = 0; i < values.length; i++) {

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -106,7 +106,7 @@ describe('merge', function () {
         for (var i = 0; i < values.length; i++) {
           newValues[i] = parseInt(values[i], 10);
         }
-        return this.apply(null, newValues);
+        return typed.self.apply(null, newValues);
       }
     });
 

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -101,8 +101,10 @@ describe('merge', function () {
     });
 
     var fn2 = typed({
-      '...string': typed.reference((resolve, self) => {
+      '...string': typed.referToSelf((self) => {
         return function (values) {
+          assert.strictEqual(self, fn3); // only holds after merging fn1 and fn2
+
           var newValues = [];
           for (var i = 0; i < values.length; i++) {
             newValues[i] = parseInt(values[i], 10);

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -101,13 +101,15 @@ describe('merge', function () {
     });
 
     var fn2 = typed({
-      '...string': function (values) {
-        var newValues = [];
-        for (var i = 0; i < values.length; i++) {
-          newValues[i] = parseInt(values[i], 10);
+      '...string': typed.reference((self) => {
+        return function (values) {
+          var newValues = [];
+          for (var i = 0; i < values.length; i++) {
+            newValues[i] = parseInt(values[i], 10);
+          }
+          return self.apply(null, newValues);
         }
-        return typed.self.apply(null, newValues);
-      }
+      })
     });
 
     var fn3 = typed(fn1, fn2);

--- a/test/rest_params.js
+++ b/test/rest_params.js
@@ -141,10 +141,6 @@ describe('rest parameters', function () {
     assert.equal(fn(2, 3), '...number');
     assert.equal(fn(2), '...number');
     assert.equal(fn({}), 'Object');
-    assert.deepEqual(Object.keys(fn.signatures), [
-      'Object',
-      '...number'
-    ]);
   });
 
   it('should split rest params with conversions in two and order them correctly', function() {

--- a/typed-function.js
+++ b/typed-function.js
@@ -229,7 +229,7 @@
 
       throw new Error('Cannot convert from ' + from + ' to ' + type);
     }
-    
+
     /**
      * Stringify parameters in a normalized way
      * @param {Param[]} params
@@ -1082,14 +1082,18 @@
       var fn = function fn(arg0, arg1) {
         'use strict';
 
-        if (arguments.length === len0 && test00(arg0) && test01(arg1)) { return fn0.apply(fn, arguments); }
-        if (arguments.length === len1 && test10(arg0) && test11(arg1)) { return fn1.apply(fn, arguments); }
-        if (arguments.length === len2 && test20(arg0) && test21(arg1)) { return fn2.apply(fn, arguments); }
-        if (arguments.length === len3 && test30(arg0) && test31(arg1)) { return fn3.apply(fn, arguments); }
-        if (arguments.length === len4 && test40(arg0) && test41(arg1)) { return fn4.apply(fn, arguments); }
-        if (arguments.length === len5 && test50(arg0) && test51(arg1)) { return fn5.apply(fn, arguments); }
+        // self contains the latest called function
+        // this is a bit dirty (should be cleaned up afterwards)
+        typed.self = fn;
 
-        return generic.apply(fn, arguments);
+        if (arguments.length === len0 && test00(arg0) && test01(arg1)) { return fn0.apply(this, arguments); }
+        if (arguments.length === len1 && test10(arg0) && test11(arg1)) { return fn1.apply(this, arguments); }
+        if (arguments.length === len2 && test20(arg0) && test21(arg1)) { return fn2.apply(this, arguments); }
+        if (arguments.length === len3 && test30(arg0) && test31(arg1)) { return fn3.apply(this, arguments); }
+        if (arguments.length === len4 && test40(arg0) && test41(arg1)) { return fn4.apply(this, arguments); }
+        if (arguments.length === len5 && test50(arg0) && test51(arg1)) { return fn5.apply(this, arguments); }
+
+        return generic.apply(this, arguments);
       }
 
       // attach name the typed function

--- a/typed-function.js
+++ b/typed-function.js
@@ -1020,8 +1020,9 @@
             var resolved = fn.referTo.callback.apply(this, resolvedReferences);
 
             // we need to keep the .referTo object (with references and callback)
-            // to be able to merge typed-functions later on: then we need to
-            // resolve the new signatures again.
+            // to be able to merge typed-functions later on: then we may need to
+            // resolve the new signatures again, though this is only the case
+            // when replacing an existing signature with another one.
             resolved.referTo = fn.referTo;
 
             signaturesMap[signature] = resolved;

--- a/typed-function.js
+++ b/typed-function.js
@@ -985,7 +985,7 @@
      */
     function verifyResolvedReference(resolvedReference, reference, signature) {
       if (!resolvedReference) {
-        throw new TypeError('Cannot refer to signature "' + signature + '": ' +
+        throw new TypeError('Cannot resolve reference in signature "' + signature + '": ' +
           'reference signature "' + reference + '" not found');
       }
 
@@ -995,7 +995,7 @@
           isReferToSelf(resolvedReference)
         )
       ) {
-        throw new TypeError('Cannot refer to signature "' + signature + '": ' +
+        throw new TypeError('Cannot resolve reference in signature "' + signature + '": ' +
           'signature is referring to a signature "' + reference + '" which is not yet resolved');
       }
     }


### PR DESCRIPTION
Keep typed-functions unbound, so they can be bound to a context by the user. Replaces `this(...)` with callbacks:

- `typed.referTo(signature1, signature2, ..., (fn1, fn2, ...) => { ... })` 
- `typed.referToSelf((self) => { ... })`

See discussion in #126 for pros/cons

To do:

- [x] Discuss API
- [x] Implement final API
- [x] Write tests
- [x] Write documentation 
- [x] Backward compatibility warnings. This PR is quite a breaking change, and I expect users will get very vague errors when using `this(...)` in a typed-function when upgrading from v2 to v3. Therefore I would like to scan the functions for occurrences of `this(...)` or `this.signatures`, and if so throw an exception. There must be an option to disable this validation step.
- [x] Refactor `resolveReferences`
