### PR TITLE
fix(typed): Return a function operating independently of type system

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,25 +165,30 @@ The following type expressions are supported:
 
 ### Construction
 
-A typed function can be constructed in two ways:
+```
+typed([name: string], ...Object.<string, function>|function)
+```
+A typed function can be constructed from an optional name and any number of
+(additional) arguments that supply the implementations for various
+signatures. Each of these further arguments must be one of the following:
 
--   Create from an object with one or multiple signatures:
+-   An object with one or multiple signatures, i.e. a plain object
+    with string keys, each of which names a signature, and functions as
+    the values of those keys.
 
-    ```
-    typed(signatures: Object.<string, function>) : function
-    typed(name: string, signatures: Object.<string, function>) : function
-    ```
+-   A previously constructed typed function, in which case all of its
+    signatures and corresponding implementations are merged into the new
+    typed function.
 
--   Merge multiple typed functions into a new typed function:
+-   A plain function with a `signature` property whose value is a string
+    giving that function's signature.
 
-    ```
-    typed(functions: ...function) : function
-    typed(name: string, functions: ...function) : function
-    ```
+The name, if specified, must be the first argument. If not specified, the new
+typed-function's name is inherited from the arguments it is composed from,
+as long as any that have names agree with one another.
 
-    Each function in `functions` can be either a typed function created before,
-    or a plain function having a `signature` property.
-
+If the same signature is specified by the collection of arguments more than
+once with different implementations, an error will be thrown.
 
 ### Methods
 

--- a/test/construction.test.js
+++ b/test/construction.test.js
@@ -69,6 +69,11 @@ describe('construction', function() {
     assert.equal(fn.name, '');
   });
 
+  it('should throw if attempting to construct from other types', () => {
+    assert.throws(() => typed(1), TypeError)
+    assert.throws(() => typed('myfunc', 'implementation'), TypeError)
+  })
+
   it('should compose a function with zero arguments', function() {
     var signatures = {
       '': function () {

--- a/test/construction.test.js
+++ b/test/construction.test.js
@@ -4,10 +4,16 @@ var typed = require('../typed-function');
 
 describe('construction', function() {
 
+  it('should throw an error when not providing any arguments', function() {
+    assert.throws(function () {
+      typed();
+    }, /Error: No signatures provided/);
+  });
+
   it('should throw an error when not providing any signatures', function() {
     assert.throws(function () {
       typed({});
-    }, /Error: No signatures provided/);
+    }, /Error: Argument .*typed.* 0 .* not/);
   });
 
   it('should create a named function', function() {

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -39,6 +39,26 @@ describe('merge', function () {
     assert.equal(typed3.name, 'typed3');
   });
 
+  it('should merge a typed function with an object of signatures', () => {
+    const typed1 = typed({boolean: b => !b, string: s => '!' + s})
+    const typed2 = typed(typed1, {number: n => 1 - n})
+
+    assert.equal(typed2(true), false)
+    assert.equal(typed2('true'), '!true')
+    assert.equal(typed2(1), 0)
+  })
+
+  it('should merge two objects of signatures', () => {
+    const typed1 = typed(
+      {boolean: b => !b, string: s => '!' + s},
+      {number: n => 1 - n}
+    )
+
+    assert.equal(typed1(true), false)
+    assert.equal(typed1('true'), '!true')
+    assert.equal(typed1(1), 0)
+  })
+
   it('should not copy conversions as exact signatures', function () {
     var typed2 = typed.create();
     typed2.conversions = [


### PR DESCRIPTION
  Prior to this commit, the typed object was itself a typed-function,
  which meant that if the client completely replaced the type system,
  `typed()` would no longer be able to supply sensible error messages.

  This commit makes the typed object a plain function (sorry, no
  more dogfooding here, unfortunately) and uses the resulting flexibility
  to allow arbitrary merges of any collection of typed functions, plain
  functions with a signature property, or objects mapping signatures to
  functions. Thus, there is no longer any artificial distinction between
  "creating" and "merging" typed functions -- one can simply specify the
  implementations for any collection of signatures in any of the available
  ways.

  Resolves #141.