### PR TITLE
fix(convert):  Ensure convert succeeds when value has multiple types

### DIFF
--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -30,13 +30,56 @@ describe('convert', function () {
     assert.strictEqual(typed.convert(true, 'string'), 'true');
     assert.strictEqual(typed.convert(true, 'number'), 1);
   });
-  
+
   it('should return same value when conversion is not needed', function () {
     assert.strictEqual(typed.convert(2, 'number'), 2);
     assert.strictEqual(typed.convert(true, 'boolean'), true);
   });
 
-  it('should throw an error when no conversion function is found', function() {
-    assert.throws(function () {typed.convert(2, 'boolean')}, /Error: Cannot convert from number to boolean/);
+  it('should throw an error when an unknown type is requested', function () {
+    assert.throws(function () { typed.convert(2, 'foo') }, /Unknown type.*foo/)
   });
+
+  it('should throw an error when no conversion function is found', function() {
+    assert.throws(
+      function () {typed.convert(2, 'boolean')},
+      /no conversions to boolean/);
+    assert.throws(
+      function () {typed.convert(null, 'string')},
+      /Cannot convert null to string/);
+  });
+
+  it('should pick the right conversion function when a value matches multiple types', () => {
+    // based on https://github.com/josdejong/typed-function/issues/128
+    const typed2 = typed.create()
+
+    typed2.types = [
+      {
+        name: 'number',
+        test: x => typeof x === 'number'
+      },
+      {
+        name: 'identifier',
+        test: x => (typeof x === 'string' &&
+          /^\p{Alphabetic}[\d\p{Alphabetic}]*$/u.test(x))
+      },
+      {
+        name: 'string',
+        test: x => typeof x === 'string'
+      }
+    ]
+
+    typed2.addConversion({ from: 'string', to: 'number', convert: x => parseFloat(x) })
+
+    const check = typed2('check', {
+      identifier: i => 'found an identifier: ' + i,
+      string: s => s + ' is just a string'
+    })
+
+    assert.strictEqual(check('xy33'), 'found an identifier: xy33')
+    assert.strictEqual(check('Wow!'), 'Wow! is just a string')
+
+    assert.strictEqual(typed2.convert('123.5', 'number'), 123.5)
+    assert.strictEqual(typed2.convert('Infinity', 'number'), Infinity)
+  })
 });

--- a/typed-function.js
+++ b/typed-function.js
@@ -250,24 +250,26 @@
     /**
      * Convert a given value to another data type.
      * @param {*} value
-     * @param {string} type
+     * @param {string} typeName
      */
-    function convert (value, type) {
-      var from = findTypeName(value);
-
+    function convert (value, typeName) {
       // check conversion is needed
-      if (type === from) {
+      const type = findTypeByName(typeName)
+      if (type.test(value)) {
         return value;
       }
-
-      for (var i = 0; i < typed.conversions.length; i++) {
-        var conversion = typed.conversions[i];
-        if (conversion.from === from && conversion.to === type) {
-          return conversion.convert(value);
+      const conversions = filterConversions(typed.conversions, [typeName]);
+      if (conversions.length === 0) {
+        throw new Error('There are no conversions to ' + typeName + ' defined.')
+      }
+      for (var i = 0; i < conversions.length; i++) {
+        const fromType = findTypeByName(conversions[i].from);
+        if (fromType.test(value)) {
+          return conversions[i].convert(value);
         }
       }
 
-      throw new Error('Cannot convert from ' + from + ' to ' + type);
+      throw new Error('Cannot convert ' + value + ' to ' + typeName);
     }
 
     /**


### PR DESCRIPTION
  Also speeds conversion by only testing for the types that can convert
  to the specified type. For example, if there are no such conversions,
  immediately throws an error (no type testing of the value, other than to
  check whether it is already the desired type, is needed).

  Resolves #128.