### PR TITLE
fix(convert): Allow more efficient type conversion in presence of overlapping types.

### DIFF
--- a/test/construction.test.js
+++ b/test/construction.test.js
@@ -179,7 +179,7 @@ describe('construction', function() {
     var typed2 = typed.create();
     function Person() {}
 
-    typed1.types.push({
+    typed1.addType({
       name: 'Person',
       test: function (x) {
         return x instanceof Person;
@@ -187,16 +187,16 @@ describe('construction', function() {
     });
 
     assert.strictEqual(typed.create, typed1.create);
-    assert.notStrictEqual(typed.types, typed1.types);
-    assert.notStrictEqual(typed.conversions, typed1.conversions);
+    assert.notStrictEqual(typed.addTypes, typed1.addTypes);
+    assert.notStrictEqual(typed.addConversion, typed1.addConversion);
 
     assert.strictEqual(typed.create, typed2.create);
-    assert.notStrictEqual(typed.types, typed2.types);
-    assert.notStrictEqual(typed.conversions, typed2.conversions);
+    assert.notStrictEqual(typed.addTypes, typed2.addTypes);
+    assert.notStrictEqual(typed.addConversion, typed2.addConversion);
 
     assert.strictEqual(typed1.create, typed2.create);
-    assert.notStrictEqual(typed1.types, typed2.types);
-    assert.notStrictEqual(typed1.conversions, typed2.conversions);
+    assert.notStrictEqual(typed1.addTypes, typed2.addTypes);
+    assert.notStrictEqual(typed1.addConversion, typed2.addConversion);
 
     typed1({
       'Person': function (p) {return 'Person'}
@@ -220,14 +220,9 @@ describe('construction', function() {
       }
     };
 
-    var objectEntry = typed2.types.find(function (entry) {
-      return entry.name === 'Object';
-    });
-    var objectIndex = typed2.types.indexOf(objectEntry);
-
+    var objectIndex = typed2._findType('Object').index;
     typed2.addType(newType);
-
-    assert.strictEqual(typed2.types[objectIndex], newType);
+    assert.strictEqual(typed2._findType('Person').index, objectIndex);
   });
 
   it('should add a type using addType at the end (after Object)', function() {
@@ -243,7 +238,7 @@ describe('construction', function() {
 
     typed2.addType(newType, false);
 
-    assert.strictEqual(typed2.types[typed2.types.length - 1], newType);
+    assert.strictEqual(typed2._findType('Person').index, typed2._map.size - 1);
   });
 
   it('should throw an error when passing an invalid type to addType', function() {
@@ -350,11 +345,12 @@ describe('construction', function() {
 
   it('should correctly order signatures', function () {
     const t2 = typed.create()
-    t2.types = [
+    t2.clear()
+    t2.addTypes([
       {name: 'foo', test: x => x[0] === 1},
       {name: 'bar', test: x => x[1] === 1},
       {name: 'baz', test: x => x[2] === 1}
-    ]
+    ])
     var fn = t2({
       baz: a => 'isbaz',
       bar: a => 'isbar',

--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -5,7 +5,7 @@ var strictEqualArray = require('./strictEqualArray');
 describe('conversion', function () {
 
   before(function () {
-    typed.conversions = [
+    typed.addConversions([
       {from: 'boolean', to: 'number', convert: function (x) {return +x;}},
       {from: 'boolean', to: 'string', convert: function (x) {return x + '';}},
       {from: 'number',  to: 'string', convert: function (x) {return x + '';}},
@@ -18,12 +18,12 @@ describe('conversion', function () {
         },
         fallible: true // TODO: not yet supported
       }
-    ];
+    ]);
   });
 
   after(function () {
     // cleanup conversions
-    typed.conversions = [];
+    typed.clearConversions();
   });
 
   it('should add conversions to a function with one argument', function() {
@@ -49,12 +49,11 @@ describe('conversion', function () {
       }
     };
 
-    assert.equal(typed2.conversions.length, 0);
+    assert.equal(typed2._nconversions, 0);
 
     typed2.addConversion(conversion);
 
-    assert.equal(typed2.conversions.length, 1);
-    assert.strictEqual(typed2.conversions[0], conversion);
+    assert.equal(typed2._nconversions, 1);
   });
 
   it('should throw an error when passing an invalid conversion object to addConversion', function() {
@@ -156,11 +155,11 @@ describe('conversion', function () {
 
   it('should add conversions to a function with rest parameters in a non-conflicting way', function() {
     var typed2 = typed.create();
-    typed2.conversions = [
+    typed2.addConversions([
       {from: 'boolean', to: 'number', convert: function (x) {return +x}},
       {from: 'string',  to: 'number', convert: function (x) {return parseFloat(x)}},
       {from: 'string', to: 'boolean', convert: function (x) {return !!x}}
-    ];
+    ]);
 
     // booleans can be converted to numbers, so the `...number` signature
     // will match. But the `...boolean` signature is a better (exact) match so that
@@ -198,9 +197,9 @@ describe('conversion', function () {
 
   it('should order conversions and type Object correctly ', function() {
     var typed2 = typed.create();
-    typed2.conversions = [
+    typed2.addConversion(
       {from: 'Date', to: 'string', convert: function (x) {return x.toISOString()}}
-    ];
+    );
 
     var fn = typed2({
       'string': function () {
@@ -344,10 +343,11 @@ describe('conversion', function () {
     });
 
     it('should select the signatures with the conversion with the lowest index (1)', function () {
-      typed.conversions = [
+      typed.clearConversions();
+      typed.addConversions([
         {from: 'boolean', to: 'string', convert: function (x) {return x + '';}},
         {from: 'boolean', to: 'number', convert: function (x) {return x + 0;}}
-      ];
+      ]);
 
       // in the following typed function, a boolean input can be converted to
       // both a string or a number, which is both ok. In that case,
@@ -364,10 +364,11 @@ describe('conversion', function () {
     });
 
     it('should select the signatures with the conversion with the lowest index (2)', function () {
-      typed.conversions = [
+      typed.clearConversions();
+      typed.addConversions([
         {from: 'boolean', to: 'number', convert: function (x) {return x + 0;}},
         {from: 'boolean', to: 'string', convert: function (x) {return x + '';}}
-      ];
+      ]);
 
       // in the following typed function, a boolean input can be converted to
       // both a string or a number, which is both ok. In that case,
@@ -382,11 +383,12 @@ describe('conversion', function () {
     });
 
     it('should select the signatures with least needed conversions (1)', function () {
-      typed.conversions = [
+      typed.clearConversions();
+      typed.addConversions([
         {from: 'number', to: 'boolean', convert: function (x) {return !!x }},
         {from: 'number', to: 'string', convert: function (x) {return x + '' }},
         {from: 'boolean', to: 'string', convert: function (x) {return x + '' }}
-      ];
+      ]);
 
       // in the following typed function, the number input can be converted to
       // both a string or a boolean, which is both ok. It should pick the
@@ -400,11 +402,12 @@ describe('conversion', function () {
     });
 
     it('should select the signatures with least needed conversions (2)', function () {
-      typed.conversions = [
+      typed.clearConversions();
+      typed.addConversions([
         {from: 'number', to: 'boolean', convert: function (x) {return !!x }},
         {from: 'number', to: 'string', convert: function (x) {return x + '' }},
         {from: 'boolean', to: 'string', convert: function (x) {return x + '' }}
-      ];
+      ]);
 
       // in the following typed function, the number input can be converted to
       // both a string or a boolean, which is both ok. It should pick the

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -4,7 +4,7 @@ var typed = require('../typed-function');
 describe('convert', function () {
 
   before(function () {
-    typed.conversions = [
+    typed.addConversions([
       {from: 'boolean', to: 'number', convert: function (x) {return +x;}},
       {from: 'boolean', to: 'string', convert: function (x) {return x + '';}},
       {from: 'number',  to: 'string', convert: function (x) {return x + '';}},
@@ -17,12 +17,12 @@ describe('convert', function () {
         },
         fallible: true // TODO: not yet supported
       }
-    ];
+    ]);
   });
 
   after(function () {
     // cleanup conversions
-    typed.conversions = [];
+    typed.clearConversions();
   });
 
   it('should convert a value', function() {
@@ -53,7 +53,8 @@ describe('convert', function () {
     // based on https://github.com/josdejong/typed-function/issues/128
     const typed2 = typed.create()
 
-    typed2.types = [
+    typed2.clear()
+    typed2.addTypes([
       {
         name: 'number',
         test: x => typeof x === 'number'
@@ -67,7 +68,7 @@ describe('convert', function () {
         name: 'string',
         test: x => typeof x === 'string'
       }
-    ]
+    ])
 
     typed2.addConversion({ from: 'string', to: 'number', convert: x => parseFloat(x) })
 

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -30,13 +30,56 @@ describe('convert', function () {
     assert.strictEqual(typed.convert(true, 'string'), 'true');
     assert.strictEqual(typed.convert(true, 'number'), 1);
   });
-  
+
   it('should return same value when conversion is not needed', function () {
     assert.strictEqual(typed.convert(2, 'number'), 2);
     assert.strictEqual(typed.convert(true, 'boolean'), true);
   });
 
-  it('should throw an error when no conversion function is found', function() {
-    assert.throws(function () {typed.convert(2, 'boolean')}, /Error: Cannot convert from number to boolean/);
+  it('should throw an error when an unknown type is requested', function () {
+    assert.throws(function () { typed.convert(2, 'foo') }, /Unknown type.*foo/)
   });
+
+  it('should throw an error when no conversion function is found', function() {
+    assert.throws(
+      function () {typed.convert(2, 'boolean')},
+      /no conversions to boolean/);
+    assert.throws(
+      function () {typed.convert(null, 'string')},
+      /Cannot convert null to string/);
+  });
+
+  it('should pick the right conversion function when a value matches multiple types', () => {
+    // based on https://github.com/josdejong/typed-function/issues/128
+    const typed2 = typed.create()
+
+    typed2.types = [
+      {
+        name: 'number',
+        test: x => typeof x === 'number'
+      },
+      {
+        name: 'identifier',
+        test: x => (typeof x === 'string' &&
+          /^\p{Alphabetic}[\d\p{Alphabetic}]*$/u.test(x))
+      },
+      {
+        name: 'string',
+        test: x => typeof x === 'string'
+      }
+    ]
+
+    typed2.addConversion({ from: 'string', to: 'number', convert: x => parseFloat(x) })
+
+    const check = typed2('check', {
+      identifier: i => 'found an identifier: ' + i,
+      string: s => s + ' is just a string'
+    })
+
+    assert.strictEqual(check('xy33'), 'found an identifier: xy33')
+    assert.strictEqual(check('Wow!'), 'Wow! is just a string')
+
+    assert.strictEqual(typed2.convert('123.5', 'number'), 123.5)
+    assert.strictEqual(typed2.convert('Infinity', 'number'), Infinity)
+  })
 });

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -139,7 +139,7 @@ describe('errors', function () {
 
   it('should only list matches of exact and convertable types', function() {
     var typed2 = typed.create();
-    typed2.conversions.push({
+    typed2.addConversion({
       from: 'number',
       to: 'string',
       convert: function (x) {

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -61,9 +61,9 @@ describe('merge', function () {
 
   it('should not copy conversions as exact signatures', function () {
     var typed2 = typed.create();
-    typed2.conversions = [
+    typed2.addConversion(
       {from: 'string', to: 'number', convert: function (x) {return parseFloat(x)}}
-    ];
+    );
 
     var fn2 = typed2({'number': function (value) { return value }});
 

--- a/test/resolve.test.js
+++ b/test/resolve.test.js
@@ -7,7 +7,7 @@ describe('resolve', function () {
     from: 'boolean', to: 'string', convert: x => '' + x
   }))
 
-  after(() => { typed.conversions = [] })
+  after(() => { typed.clearConversions() })
 
   it('should choose the signature that direct execution would', () => {
     const fn = typed({

--- a/test/rest_params.js
+++ b/test/rest_params.js
@@ -145,9 +145,9 @@ describe('rest parameters', function () {
 
   it('should split rest params with conversions in two and order them correctly', function() {
     var typed2 = typed.create()
-    typed2.conversions = [
+    typed2.addConversion(
       {from: 'string', to: 'number', convert: function (x) {return parseFloat(x)}}
-    ];
+    );
 
     var fn = typed2({
       '...number': function (values) {

--- a/typed-function.js
+++ b/typed-function.js
@@ -250,24 +250,26 @@
     /**
      * Convert a given value to another data type.
      * @param {*} value
-     * @param {string} type
+     * @param {string} typeName
      */
-    function convert (value, type) {
-      var from = findTypeName(value);
-
+    function convert (value, typeName) {
       // check conversion is needed
-      if (type === from) {
+      const type = findTypeByName(typeName)
+      if (type.test(value)) {
         return value;
       }
-
-      for (var i = 0; i < typed.conversions.length; i++) {
-        var conversion = typed.conversions[i];
-        if (conversion.from === from && conversion.to === type) {
-          return conversion.convert(value);
+      const conversions = filterConversions(typed.conversions, [typeName]);
+      if (conversions.length === 0) {
+        throw new Error('There are no conversions to ' + typeName + ' defined.')
+      }
+      for (var i = 0; i < conversions.length; i++) {
+        const fromType = findTypeByName(conversions[i].from);
+        if (fromType.test(value)) {
+          return conversions[i].convert(value);
         }
       }
 
-      throw new Error('Cannot convert from ' + from + ' to ' + type);
+      throw new Error('Cannot convert ' + value + ' to ' + typeName);
     }
 
     /**


### PR DESCRIPTION
This is actually built on top of #143, but takes advantage of the fact that v3 is a breaking change to disallow direct access to typed.types and typed.conversions. This way more efficient data structures can be maintained through a functional interface typed.addTypes(), typed.addConversions(), typed.clear(), typed.clearConversions(), making type lookup and conversion significantly more efficient.  It seems like future improvements to typed-function will need to prevent direct manipulation of the internal data structures of types and conversions, so that they can be kept organized in a useful way, so v3 seems like a good opportunity to make that breaking change.

If this is of interest, another small commit will be needed to update the documentation, but I wanted to get something in for you to review as it's getting late and I know that there's interest in completing v3 and moving on.  I've just had so many times that it's been frustrating that there is direct access to typed.types (in particular, that prevented reorganizing the types as a Map from type name to objects with test functions, etc.) that I wanted to make the case that this was a good point to make that breaking change. If you like that, I can polish this up to be really ready to merge tomorrow. Thanks for considering.