### PR TITLE
Extend the benchmark section

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,8 @@
 - Refactored the `typed` constructor to be more flexible, accepting a
   combination of multiple typed functions or objects. And internally refactored
   the constructor to not use typed-function itself (#142). Thanks @gwhitney.
+- Extended the benchmark script and added counting of creation of typed
+  functions (#146).
 
 
 ## 2022-03-11, version 2.1.0

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -116,6 +116,8 @@ suite
     console.log(String(event.target));
   })
   .on('complete', function() {
+    console.log('First typed universe created', typed.createCount, 'functions')
+    console.log('typed2 universe created', typed2.createCount, 'functions')
   })
   .run();
 

--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -9,63 +9,194 @@
 // Before running, make sure you've installed the needed packages which
 // are defined in the devDependencies of the project.
 //
-// To create a bundle:
+// To create a bundle for testing in a browser:
 //
 //     browserify -o benchmark/benchmark.bundle.js benchmark/benchmark.js
 //
-
-'use strict';
-
-var assert = require('assert');
-var Benchmark = require('benchmark');
-var padRight = require('pad-right');
-var typed = require('../typed-function');
+const assert = require('assert');
+const Benchmark = require('benchmark');
+const padRight = require('pad-right');
+const typed = require('../typed-function');
 
 // expose on window when using bundled in a browser
 if (typeof window !== 'undefined') {
   window['Benchmark'] = Benchmark;
 }
 
-function add(x, y) {
+function vanillaAdd(x, y) {
   return x + y;
 }
 
-var signatures = {
-  'number, number': add,
-  'boolean, boolean': add,
-  'Date, Date': add,
-  'string, string': add
-};
+const typedAdd = typed('add', {
+  'number, number': (x, y) => x + y,
+  'boolean, boolean': (x, y) => x + y,
+  'Date, Date': (x, y) => x + y,
+  'string, string': (x, y) => x + y
+});
 
-var addTyped = typed('add', signatures);
+assert.strictEqual(vanillaAdd(2,3), 5);
+assert.strictEqual(typedAdd(2, 3), 5);
+assert.strictEqual(typedAdd('hello', 'world'), 'helloworld');
+assert.throws(function () { typedAdd(1) }, /TypeError/)
+assert.throws(function () { typedAdd(1,2,3) }, /TypeError/)
 
-assert(add(2,3), 5);
-assert(addTyped(2,3), 5);
-assert(addTyped('hello', 'world'), 'helloworld');
-assert.throws(function () { addTyped(1) }, /TypeError/)
-assert.throws(function () { addTyped(1,2,3) }, /TypeError/)
+const typed2 = createTyped(11, 10)
 
-var result = 0;
-var suite = new Benchmark.Suite();
+const typed1Signature0Conversions = createTyped1Signature0Conversions(typed2)
+assert.strictEqual(typed1Signature0Conversions('Type0', 'Type0'), 'Result:Type0:Type0')
+
+const typed10Signatures0Conversions = createTyped10Signatures0Conversions(typed2)
+assert.strictEqual(typed10Signatures0Conversions('Type0', 'Type0'), 'Result:Type0:Type0')
+assert.strictEqual(typed10Signatures0Conversions('Type7', 'Type7'), 'Result:Type7:Type7')
+
+const typed1Signature10Conversions = createTyped1Signature10Conversions(typed2)
+assert.strictEqual(typed1Signature10Conversions('Type0', 'Type0'), 'Result:Type0->TypeBase:Type0')
+assert.strictEqual(typed1Signature10Conversions('Type7', 'Type0'), 'Result:Type7->TypeBase:Type0')
+
+const typed10Signatures10Conversions = createTyped10Signatures10Conversions(typed2)
+assert.strictEqual(typed10Signatures10Conversions('TypeBase', 'Type0'), 'Result:TypeBase:Type0')
+assert.strictEqual(typed10Signatures10Conversions('Type7', 'Type0'), 'Result:Type7->TypeBase:Type0')
+assert.strictEqual(typed10Signatures10Conversions('Type7', 'Type5'), 'Result:Type7->TypeBase:Type5')
+
+const paramsCount = 20
+const manyParams = Array(paramsCount).fill('Type0')
+const typed1SignatureManyParams = createTyped1SignatureManyParams(typed2, paramsCount)
+assert.strictEqual(typed1SignatureManyParams.apply(null, manyParams),'Result:' + manyParams.join(':'))
+
+const suite = new Benchmark.Suite('typed-function');
+
+let result = 0;
 suite
-    .add(pad('typed add'), function() {
-      result += addTyped(result, 4);
-      result += addTyped(String(result), 'world').length;
-    })
-    .add(pad('native add'), function() {
-      result += add(result, 4);
-      result += add(String(result), 'world').length;
-    })
-    .on('cycle', function(event) {
-      console.log(String(event.target));
-    })
-    .on('complete', function() {
-      if (result > Infinity) {
-        console.log()
+  // compare vanilla vs typed execution
+  .add(pad('execute: vanillaAdd'), function() {
+    result += vanillaAdd(result, 4);
+    result += vanillaAdd(String(result), 'world').length;
+  })
+  .add(pad('execute: typedAdd'), function() {
+    result += typedAdd(result, 4);
+    result += typedAdd(String(result), 'world').length;
+  })
+
+  // see execution time of various typed functions
+  .add(pad('execute:  1 signature,   0 conversions'), function() {
+    typed1Signature0Conversions('Type0', 'Type0')
+  })
+  .add(pad('execute: 10 signatures,  0 conversions'), function() {
+    typed10Signatures0Conversions('Type0', 'Type0')
+  })
+  .add(pad('execute:  1 signatures, 10 conversions'), function() {
+    typed1Signature10Conversions('Type0', 'Type0')
+  })
+  .add(pad('execute: 10 signatures, 10 conversions'), function() {
+    typed10Signatures10Conversions('Type0', 'Type0')
+  })
+  .add(pad(`execute:  1 signature,  ${paramsCount} params`), function() {
+    typed1SignatureManyParams.apply(null, manyParams)
+  })
+
+  // see creation time of various typed functions
+  .add(pad('create:   1 signature,   0 conversions'), function() {
+    createTyped1Signature0Conversions(typed2)
+  })
+  .add(pad('create:  10 signatures,  0 conversions'), function() {
+    createTyped10Signatures0Conversions(typed2)
+  })
+  .add(pad('create:   1 signatures, 10 conversions'), function() {
+    createTyped1Signature10Conversions(typed2)
+  })
+  .add(pad('create:  10 signatures, 10 conversions'), function() {
+    createTyped10Signatures10Conversions(typed2)
+  })
+  .add(pad(`create:   1 signature,  ${paramsCount} params`), function() {
+    createTyped1SignatureManyParams(typed2, paramsCount)
+  })
+
+  // run and output stuff
+  .on('cycle', function(event) {
+    console.log(String(event.target));
+  })
+  .on('complete', function() {
+  })
+  .run();
+
+function createTyped1Signature0Conversions(typed) {
+  return typed('1Signature', {
+    'Type0,Type0': (a, b) => 'Result:' + a + ':' + b
+  })
+}
+
+function createTyped10Signatures0Conversions(typed) {
+  const count = 10
+
+  const signatures = {}
+  for (let t = 0; t < count; t++) {
+    signatures[`Type${t}, Type${t}`] = (a, b) => 'Result:' + a + ':' + b
+  }
+
+  return typed('10Signatures', signatures)
+}
+
+function createTyped1Signature10Conversions(typed) {
+  return typed('1Signature10conversions', {
+    'TypeBase, Type0': (a, b) => 'Result:' + a + ':' + b
+  })
+}
+
+function createTyped10Signatures10Conversions(typed) {
+  const count = 10
+  const signatures = {}
+  for (let t = 0; t < count; t++) {
+    signatures[`TypeBase, Type${t}`] = (a, b) => 'Result:' + a + ':' + b
+  }
+
+  return typed('10Signatures10conversions', signatures)
+}
+
+function createTyped1SignatureManyParams(typed, paramsCount) {
+  const signatureStr = Array(paramsCount).fill('Type0')
+
+  return typed(`1Signature${paramsCount}Params`, {
+    [signatureStr]: (...args) => 'Result:' + args.join(':')
+  })
+}
+
+function createTyped(typeCount, conversionCount) {
+  const newTyped = typed.create()
+  newTyped.types = []
+  newTyped.conversions = []
+
+  const baseName = 'TypeBase'
+  newTyped.addType({
+    name: baseName,
+    test: function (value) {
+      return typeof value === 'string' && value === baseName
+    }
+  })
+
+  for (let t = 0; t < typeCount; t++) {
+    const name = 'Type' + t
+
+    newTyped.addType({
+      name,
+      test: function (value) {
+        return typeof value === 'string' && value === name
       }
     })
-    .run();
+  }
+
+  for (let c = 0; c < conversionCount; c++) {
+    newTyped.addConversion({
+      from: 'Type' + c,
+      to: baseName,
+      convert: function (value) {
+        return value + '->' + baseName;
+      }
+    })
+  }
+
+  return newTyped
+}
 
 function pad (text) {
-  return padRight(text, 20, ' ');
+  return padRight(text, 40, ' ');
 }

--- a/test/construction.test.js
+++ b/test/construction.test.js
@@ -366,6 +366,12 @@ describe('construction', function() {
         ['number', 'string', 'boolean']);
   });
 
+  it('should increment the count of typed functions', function () {
+    const saveCount = typed.createCount;
+    const fn = typed({number: () => true});
+    assert.strictEqual(typed.createCount - saveCount, 1);
+  });
+
   it('should allow a function to be defined recursively', function () {
     var fn = typed({
       'number': function (value) {

--- a/typed-function.js
+++ b/typed-function.js
@@ -104,7 +104,8 @@
     var typed = {
       types: _types,
       conversions: _conversions,
-      ignore: _ignore
+      ignore: _ignore,
+      createCount: 0
     };
 
     /**
@@ -982,6 +983,8 @@
      * @return {function}  Returns the created typed function.
      */
     function createTypedFunction(name, signaturesMap) {
+      typed.createCount++
+
       if (Object.keys(signaturesMap).length === 0) {
         throw new SyntaxError('No signatures provided');
       }
@@ -1321,6 +1324,7 @@
       }
     }
 
+    const saveTyped = typed
     /**
      * Originally the main function was a typed function itself, but then
      * it might not be able to generate error messages if the client
@@ -1391,6 +1395,7 @@
     typed.types = _types;
     typed.conversions = _conversions;
     typed.ignore = _ignore;
+    typed.createCount = saveTyped.createCount;
     typed.onMismatch = _onMismatch;
     typed.throwMismatchError = _onMismatch;
     typed.createError = createError;


### PR DESCRIPTION
I extended the benchmark section to compare creating/executing of typed functions with varying number of signatures, conversions, params. This can be used compare for regressions/improvements when implementing new features or refactoring stuff.

Example output:

```
> node .\benchmark\benchmark.js
execute: vanillaAdd                      x 28,583,317 ops/sec ±2.69% (92 runs sampled)
execute: typedAdd                        x 27,209,671 ops/sec ±0.29% (93 runs sampled)
execute:  1 signature,   0 conversions   x 29,603,229 ops/sec ±0.42% (93 runs sampled)
execute: 10 signatures,  0 conversions   x 28,929,622 ops/sec ±2.18% (93 runs sampled)
execute:  1 signatures, 10 conversions   x 10,351,809 ops/sec ±0.40% (96 runs sampled)
execute: 10 signatures, 10 conversions   x 4,610,580 ops/sec ±0.28% (93 runs sampled)
execute:  1 signature,  20 params        x 997,103 ops/sec ±0.46% (95 runs sampled)
create:   1 signature,   0 conversions   x 193,731 ops/sec ±0.65% (93 runs sampled)
create:  10 signatures,  0 conversions   x 22,061 ops/sec ±0.90% (91 runs sampled)
create:   1 signatures, 10 conversions   x 60,337 ops/sec ±1.35% (91 runs sampled)
create:  10 signatures, 10 conversions   x 4,957 ops/sec ±0.34% (94 runs sampled)
create:   1 signature,  20 params        x 30,263 ops/sec ±0.45% (95 runs sampled)
```

@gwhitney  can you have a look at this PR? Feel free to merge it right away in `develop`. And feel free to make further improvements if needed.