### PR TITLE
Alternate branch for Version 3

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,8 +9,8 @@ Breaking changes:
 
 - Fix #14: conversions now have preference over `any`. Thanks @gwhitney.
 
-- The properties `typed.types` and `typed.conversions` are now private. 
-    Instead of adding and removing types and conversions directly on those
+- The properties `typed.types` and `typed.conversions` have been removed.
+    Instead of adding and removing types and conversions with those
     arrays, use the methods `addType`, `addTypes`, `addConversion`, 
     `addConversions`, `removeConversion`, `clear`, `clearConversions`.
 
@@ -50,8 +50,9 @@ Breaking changes:
     })
     ```
   
--   The option `type.ignore` is removed. If you need it, see if you can create 
-    a new `typed` instance without the types that you want to ignore.
+-   The property `typed.ignore` is removed. If you need it, see if you can
+    create a new `typed` instance without the types that you want to ignore, or
+    filter the signatures passed to `typed()` by hand.
 
 Non-breaking changes:
 
@@ -60,8 +61,7 @@ Non-breaking changes:
     - `typed.referToSelf(callback: (self) => function)`
     - `typed.isTypedFunction(entity: any): boolean`
     - `typed.resolve(fn: typed-function, argList: Array<any>): signature-object`
-    - `typed.find(fn: typed-function, signature: string | Array, exact: boolean) : function`
-    - `typed.findSignature(fn: typed-function, signature: string | Array, exact: boolean) : signature-object`
+    - `typed.findSignature(fn: typed-function, signature: string | Array, options: object) : signature-object`
     - `typed.addType(type: {name: string, test: function, ignored?: boolean} [, beforeObjectTest=true]): void`
     - `typed.addTypes(types: TypeDef[] [, before = 'any']): void`
     - `typed.clear(): void`
@@ -73,8 +73,13 @@ Non-breaking changes:
     the constructor to not use typed-function itself (#142). Thanks @gwhitney.
 -   Extended the benchmark script and added counting of creation of typed
     functions (#146).
--   Fixes in `typed.find()` now correctly handling cases with rest parameters. 
+-   Fixes and extensions to `typed.find()` now correctly handling cases with
+    rest or `any` parameters and matches requiring conversions; adds an
+    `options` argument to control whether matches with conversions are allowed.
     Thanks @gwhitney.
+-   Fix to `typed.convert()`: Will now find a conversion even in presence of
+    overlapping types.
+-   Reports all matching types in runtime errors, not just the first one.
 -   Improved documentation. Thanks @gwhitney. 
 
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,13 +1,81 @@
 # History
 
 
-## not yet published, version 2.1.1
+## not yet published, version 3.0.0
 
-- Refactored the `typed` constructor to be more flexible, accepting a
-  combination of multiple typed functions or objects. And internally refactored
-  the constructor to not use typed-function itself (#142). Thanks @gwhitney.
-- Extended the benchmark script and added counting of creation of typed
-  functions (#146).
+!!! BE CAREFUL: BREAKING CHANGES !!!
+
+Breaking changes:
+
+- Fix #14: conversions now have preference over `any`. Thanks @gwhitney.
+
+- The properties `typed.types` and `typed.conversions` are now private. 
+    Instead of adding and removing types and conversions directly on those
+    arrays, use the methods `addType`, `addTypes`, `addConversion`, 
+    `addConversions`, `removeConversion`, `clear`, `clearConversions`.
+
+- The `this` variable is no longer bound to the typed function itself but is 
+    unbound. Instead, use `typed.referTo(...)` and `typed.referToSelf(...)`.
+
+    By default, all function bodies will be scanned against the deprecated 
+    usage pattern of `this`, and an error will be thrown when encountered. To 
+    disable this validation step, set `typed.warnAgainstDeprecatedThis = false`.
+
+    Example:
+ 
+    ```js
+    // old:
+    const square = typed({
+      'number': x => x * x,
+      'string': x => this(parseFloat(x))
+    })
+  
+    // new:
+    const square = typed({
+      'number': x => x * x,
+      'string': typed.referToSelf(function (self) {
+        // using self is not optimal, if possible,  
+        // refer to a specific signature instead, 
+        // see next example
+        return x => self(parseFloat(x))
+      })
+    })
+
+    // optimized new:
+    const square = typed({
+      'number': x => x * x,
+      'string': typed.referTo('number', function (squareNumber) {
+        return x => sqrtNumber(parseFloat(x))
+      })
+    })
+    ```
+  
+-   The option `type.ignore` is removed. If you need it, see if you can create 
+    a new `typed` instance without the types that you want to ignore.
+
+Non-breaking changes:
+
+-   Implemented new static functions, Thanks @gwhitney:
+    - `typed.referTo(...string, callback: (resolvedFunctions: ...function) => function)`
+    - `typed.referToSelf(callback: (self) => function)`
+    - `typed.isTypedFunction(entity: any): boolean`
+    - `typed.resolve(fn: typed-function, argList: Array<any>): signature-object`
+    - `typed.find(fn: typed-function, signature: string | Array, exact: boolean) : function`
+    - `typed.findSignature(fn: typed-function, signature: string | Array, exact: boolean) : signature-object`
+    - `typed.addType(type: {name: string, test: function, ignored?: boolean} [, beforeObjectTest=true]): void`
+    - `typed.addTypes(types: TypeDef[] [, before = 'any']): void`
+    - `typed.clear(): void`
+    - `typed.addConversions(conversions: ConversionDef[]): void`
+    - `typed.removeConversion(conversion: ConversionDef): void`
+    - `typed.clearConversions(): void`
+-   Refactored the `typed` constructor to be more flexible, accepting a
+    combination of multiple typed functions or objects. And internally refactored
+    the constructor to not use typed-function itself (#142). Thanks @gwhitney.
+-   Extended the benchmark script and added counting of creation of typed
+    functions (#146).
+-   Fixes in `typed.find()` now correctly handling cases with rest parameters. 
+    Thanks @gwhitney.
+-   Improved documentation. Thanks @gwhitney. 
 
 
 ## 2022-03-11, version 2.1.0

--- a/README.md
+++ b/README.md
@@ -335,9 +335,11 @@ once with different implementations, an error will be thrown.
     and so could be deceived by another object with the same property, although
     the property is chosen so that's unlikely to happen unintentionally.
 
--   `typed.addType(type: {name: string, test: function} [, beforeObjectTest=true]): void`
+-   `typed.addType(type: {name: string, test: function, ignored?: boolean} [, beforeObjectTest=true]): void`
 
-    Add a new type. A type object contains a name and a test function.
+    Add a new type. A type object contains a name and a test function, and
+    optionally an ignored flag which defaults to false and specifies whether
+    tye type should initially be ignored.
     The order of the types determines in which order function arguments are 
     type-checked, so for performance it's important to put the most used types 
     first. All types are added to the Array `typed.types`. 
@@ -371,6 +373,34 @@ once with different implementations, an error will be thrown.
     is similar to `typed.addType` as well, except it should be the name of an
     arbitrary type that has already been added (rather than just a boolean flag)
 
+-   `typed.ignore(name: string newStatus?: boolean): boolean`
+
+    If this function is called with a boolean argument newStatus, sets the
+    type of the given name to be ignored or not, according to newStatus,
+    when creating a typed function or determining the type of a value.
+
+    In any case, returns the ignored status of the type prior to this call.
+
+    This can be useful to filter signatures when creating a typed function.
+    For example:
+
+    ```js
+    // a set with signatures maybe loaded from somewhere
+    var signatures = {
+      'number': function () {...},
+      'string': function () {...}
+    }
+
+    // we want to ignore a specific type
+    const prevStatus = typed.ignore('string', true);
+
+    // the created function fn will only contain the 'number' signature
+    var fn = typed('fn', signatures);
+
+    // go back to the previous status for 'string'
+    typed.ignore('string', prevStatus);
+    ```
+
 -   `typed.clear(): void`
 
     Removes all types and conversions from the typed instance. Note that any
@@ -401,6 +431,12 @@ once with different implementations, an error will be thrown.
     `conversions` array should be an object like the `conversion` argument of
     `typed.addConversion`.
 
+-   `typed.removeConversion(conversion: ConversionDef): void`
+
+    Removes a single existing conversion. An error is thrown if there is no
+    conversion from and to the given types with a strictly equal convert
+    function as supplied in this call.
+
 -   `typed.clearConversions(): void`
 
     Removes all conversions from the typed instance (leaving the types alone).
@@ -416,26 +452,6 @@ once with different implementations, an error will be thrown.
     you want to throw the error that the default handler would have.
 
 ### Properties
-
--   `typed.ignore: Array.<string>`
-
-    An Array with names of types to be ignored when creating a typed function.
-    This can be useful to filter signatures when creating a typed function.
-    For example:
-
-    ```js
-    // a set with signatures maybe loaded from somewhere
-    var signatures = {
-      'number': function () {...},
-      'string': function () {...}
-    }
-
-    // we want to ignore a specific type
-    typed.ignore = ['string'];
-
-    // the created function fn will only contain the 'number' signature 
-    var fn = typed('fn', signatures);
-    ```
 
 -   `typed.onMismatch: function`
 

--- a/README.md
+++ b/README.md
@@ -300,17 +300,31 @@ once with different implementations, an error will be thrown.
     (such as bookkeeping or additional custom error checking) between
     signature selection and execution dispatch.
 
--   `typed.find(fn: typed-function, signature: string | Array) : function | null`
+-   `typed.findSignature(fn: typed-function, signature: string | Array, exact: boolean) : signature-object`
 
-    Find a specific signature from a typed function. The function currently
-    only finds exact matching signatures.
+    Find the signature object (as returned by `typed.resolve` above), but
+    based on the specification of a signature (given either as a
+    comma-separated string of parameter types, or an Array of strings giving
+    the parameter types), rather than based on an example argument list.
+
+    The optional third argument, which defaults to false, specifies whether
+    to limit the search to exact type matches, i.e. signatures for which the
+    implementation was directly defined when the typed-function was created
+    (as opposed to signatures that require a type conversion).
+
+    Throws an error if the signature is not found.
+
+-   `typed.find(fn: typed-function, signature: string | Array, exact: boolean) : function`
+
+    Convenience method that returns just the implementation from the
+    signature object produced by `typed.findSignature(fn, signature, exact)`.
     
     For example:
     
     ```js
     var fn = typed(...);
     var f = typed.find(fn, ['number', 'string']);
-    var f = typed.find(fn, 'number, string');
+    var f = typed.find(fn, 'number, string', 'exact');
     ```
 
 -   `typed.isTypedFunction(entity: any): boolean`

--- a/README.md
+++ b/README.md
@@ -420,34 +420,6 @@ once with different implementations, an error will be thrown.
     is similar to `typed.addType` as well, except it should be the name of an
     arbitrary type that has already been added (rather than just a boolean flag)
 
--   `typed.ignore(name: string newStatus?: boolean): boolean`
-
-    If this function is called with a boolean argument newStatus, sets the
-    type of the given name to be ignored or not, according to newStatus,
-    when creating a typed function or determining the type of a value.
-
-    In any case, returns the ignored status of the type prior to this call.
-
-    This can be useful to filter signatures when creating a typed function.
-    For example:
-
-    ```js
-    // a set with signatures maybe loaded from somewhere
-    var signatures = {
-      'number': function () {...},
-      'string': function () {...}
-    }
-
-    // we want to ignore a specific type
-    const prevStatus = typed.ignore('string', true);
-
-    // the created function fn will only contain the 'number' signature
-    var fn = typed('fn', signatures);
-
-    // go back to the previous status for 'string'
-    typed.ignore('string', prevStatus);
-    ```
-
 -   `typed.clear(): void`
 
     Removes all types and conversions from the typed instance. Note that any

--- a/README.md
+++ b/README.md
@@ -251,15 +251,17 @@ once with different implementations, an error will be thrown.
 -   `typed.convert(value: *, type: string) : *`
 
     Convert a value to another type. Only applicable when conversions have
-    been defined in `typed.conversions` (see section [Properties](#properties)). 
+    been added with `typed.addConversion()` and/or `typed.addConversion()`
+    (see below in the method list).
     Example:
     
     ```js
-    typed.conversions.push({
+    typed.addConversion({
       from: 'number',
       to: 'string',
       convert: function (x) {
         return +x;
+      }
     });
     
     var str = typed.convert(2.3, 'string'); // '2.3' 
@@ -300,24 +302,25 @@ once with different implementations, an error will be thrown.
     (such as bookkeeping or additional custom error checking) between
     signature selection and execution dispatch.
 
--   `typed.findSignature(fn: typed-function, signature: string | Array, exact: boolean) : signature-object`
+-   `typed.findSignature(fn: typed-function, signature: string | Array, options: object) : signature-object`
 
     Find the signature object (as returned by `typed.resolve` above), but
     based on the specification of a signature (given either as a
     comma-separated string of parameter types, or an Array of strings giving
     the parameter types), rather than based on an example argument list.
 
-    The optional third argument, which defaults to false, specifies whether
-    to limit the search to exact type matches, i.e. signatures for which the
-    implementation was directly defined when the typed-function was created
-    (as opposed to signatures that require a type conversion).
+    The optional third argument, is a plain object giving options controlling
+    the search. Currently, the only implemented option is `exact`, which if
+    true (defaults to false), limits the search to exact type matches,
+    i.e. signatures for which no conversion functions need to be called in
+    order to apply the function.
 
     Throws an error if the signature is not found.
 
--   `typed.find(fn: typed-function, signature: string | Array, exact: boolean) : function`
+-   `typed.find(fn: typed-function, signature: string | Array, options: object) : function`
 
     Convenience method that returns just the implementation from the
-    signature object produced by `typed.findSignature(fn, signature, exact)`.
+    signature object produced by `typed.findSignature(fn, signature, options)`.
     
     For example:
     
@@ -382,14 +385,13 @@ once with different implementations, an error will be thrown.
     and so could be deceived by another object with the same property, although
     the property is chosen so that's unlikely to happen unintentionally.
 
--   `typed.addType(type: {name: string, test: function, ignored?: boolean} [, beforeObjectTest=true]): void`
+-   `typed.addType(type: {name: string, test: function, [, beforeObjectTest=true]): void`
 
-    Add a new type. A type object contains a name and a test function, and
-    optionally an ignored flag which defaults to false and specifies whether
-    tye type should initially be ignored.
+    Add a new type. A type object contains a name and a test function.
     The order of the types determines in which order function arguments are 
     type-checked, so for performance it's important to put the most used types 
-    first. All types are added to the Array `typed.types`. 
+    first. Also, if one type is contained in another, it should likely precede
+    it in the type order so that it won't be masked in type testing.
     
     Example:
     
@@ -428,7 +430,7 @@ once with different implementations, an error will be thrown.
 
 -   `typed.addConversion(conversion: {from: string, to: string, convert: function}) : void`
 
-    Add a new conversion. Conversions are added to the Array `typed.conversions`.
+    Add a new conversion.
     
     ```js
     typed.addConversion({

--- a/README.md
+++ b/README.md
@@ -162,6 +162,37 @@ The following type expressions are supported:
 - Variable arguments: `...number`
 - Any type: `any`
 
+### Dispatch
+
+When a typed function is called, an implementation with a matching signature
+is called, where conversions may be applied to actual arguments in order to
+find a match.
+
+Among all matching signatures, the one to execute is chosen by the following
+preferences, in order of priority:
+
+* one that does not have an `...any` parameter
+* one with the fewest `any` parameters
+* one that does not use conversions to match a rest parameter
+* one with the fewest conversions needed to match overall
+* one with no rest parameter
+* If there's a rest parameter, the one with the most non-rest parameters
+* The one with the largest number of preferred parameters
+* The one with the earliest preferred parameter
+
+When this process gets to the point of comparing individual parameters,
+the preference between parameters is determined by the following, in
+priority order:
+
+* All specific types are preferred to the 'any' type
+* All directly matching types are preferred to conversions
+* Types earlier in the list of known types are preferred
+* Among conversions, ones earlier in the list are preferred
+
+If none of these aspects produces a preference, then in those contexts in
+which Array.sort is stable, the order implementations were listed when
+the typed-function was created breaks the tie. Otherwise the dispatch may
+select any of the "tied" implementations.
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -364,6 +364,19 @@ once with different implementations, an error will be thrown.
     `typed-function` would never reach the new type. When `beforeObjectTest`
     is `false`, the new type will be added at the end of all tests.
 
+-   `typed.addTypes(types: TypeDef[] [, before = 'any']): void`
+
+    Adds an list of new types. Each entry of the `types` array is an object
+    like the `type` argument to `typed.addType`. The optional `before` argument
+    is similar to `typed.addType` as well, except it should be the name of an
+    arbitrary type that has already been added (rather than just a boolean flag)
+
+-   `typed.clear(): void`
+
+    Removes all types and conversions from the typed instance. Note that any
+    typed-functions created before a call to `clear` will still operate, but
+    they may prouce unintelligible messages in case of type mismatch errors.
+
 -   `typed.addConversion(conversion: {from: string, to: string, convert: function}) : void`
 
     Add a new conversion. Conversions are added to the Array `typed.conversions`.
@@ -382,6 +395,16 @@ once with different implementations, an error will be thrown.
     best to add all of your desired automatic conversions before defining any
     typed functions.
 
+-   `typed.addConversions(conversions: ConversionDef[]): void`
+
+    Convenience method that adds a list of conversions. Each element in the
+    `conversions` array should be an object like the `conversion` argument of
+    `typed.addConversion`.
+
+-   `typed.clearConversions(): void`
+
+    Removes all conversions from the typed instance (leaving the types alone).
+
 -   `typed.createError(name: string, args: Array.<any>, signatures: Array.<Signature>): TypeError`
 
     Generates a custom error object reporting the problem with calling
@@ -394,45 +417,6 @@ once with different implementations, an error will be thrown.
 
 ### Properties
 
--   `typed.types: Array.<{name: string, test: function}>`
-
-    Array with types. Each object contains a type name and a test function.
-    The order of the types determines in which order function arguments are 
-    type-checked, so for performance it's important to put the most used types 
-    first. Custom types can be added like:
-
-    ```js
-    function Person(...) {
-      ...
-    }
-    
-    Person.prototype.isPerson = true;
-
-    typed.types.push({
-      name: 'Person',
-      test: function (x) {
-        return x && x.isPerson === true;
-      }
-    });
-    ```
-
--   `typed.conversions: Array.<{from: string, to: string, convert: function}>`
-
-    An Array with built-in conversions. Empty by default. Can be used to define
-    conversions from `boolean` to `number`. For example:
-
-    ```js
-    typed.conversions.push({
-      from: 'boolean',
-      to: 'number',
-      convert: function (x) {
-        return +x;
-    });
-    ```
-
-    Also note the `addConversion()` method above for simply adding a single
-    conversion at a time.
-    
 -   `typed.ignore: Array.<string>`
 
     An Array with names of types to be ignored when creating a typed function.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # typed-function
 
+** Version 3 in development **
+
 [![Version](https://img.shields.io/npm/v/typed-function.svg)](https://www.npmjs.com/package/typed-function)
 [![Downloads](https://img.shields.io/npm/dm/typed-function.svg)](https://www.npmjs.com/package/typed-function)
 [![Build Status](https://github.com/josdejong/typed-function/workflows/Node.js%20CI/badge.svg)](https://github.com/josdejong/typed-function/actions)

--- a/test/any_type.test.js
+++ b/test/any_type.test.js
@@ -76,7 +76,7 @@ describe('any type', function () {
     });
 
     assert(fn.signatures instanceof Object);
-    assert.deepEqual(Object.keys(fn.signatures), ['string,any', 'any']);
+    assert.deepEqual(Object.keys(fn.signatures), ['any', 'string,any']);
     assert.equal(fn('foo', 2), 'string,any');
     assert.equal(fn([]), 'any');
     assert.equal(fn('foo'), 'any');

--- a/test/any_type.test.js
+++ b/test/any_type.test.js
@@ -76,7 +76,9 @@ describe('any type', function () {
     });
 
     assert(fn.signatures instanceof Object);
-    assert.deepEqual(Object.keys(fn.signatures), ['any', 'string,any']);
+    assert.equal(Object.keys(fn.signatures).length, 2);
+    assert.ok('any' in fn.signatures);
+    assert.ok('string,any' in fn.signatures);
     assert.equal(fn('foo', 2), 'string,any');
     assert.equal(fn([]), 'any');
     assert.equal(fn('foo'), 'any');

--- a/test/compose.test.js
+++ b/test/compose.test.js
@@ -15,8 +15,7 @@ describe('compose', function () {
     assert.equal(fn(false, true), 'B');
     assert.equal(fn(false, 2), 'B');
     assert.equal(fn('str'), 'C');
-    // FIXME: should return correct error message
-    assert.throws(function () {fn()},           /TypeError: Too few arguments in function unnamed \(expected: number or string or boolean, index: 0\)/);
+    assert.throws(function () {fn()},           /TypeError: Too few arguments in function unnamed \(expected: string or number or boolean, index: 0\)/);
     assert.throws(function () {fn(1,2,3)},      /TypeError: Unexpected type of argument in function unnamed \(expected: boolean, actual: number, index: 1\)/);
     assert.throws(function () {fn('str', 2)},   /TypeError: Unexpected type of argument in function unnamed \(expected: boolean, actual: number, index: 1\)/);
     assert.throws(function () {fn(true, 'str')},/TypeError: Unexpected type of argument in function unnamed \(expected: number or boolean, actual: string, index: 1\)/);

--- a/test/construction.test.js
+++ b/test/construction.test.js
@@ -287,24 +287,6 @@ describe('construction', function() {
     }, /Error: Unknown type "foo"/);
   });
 
-  it('should ignore types marked so by typed.ignore', function() {
-    var typed2 = typed.create();
-    typed2.ignore('string', true);
-
-    var fn = typed2({
-      'number': function () {},
-      'number, number': function () {},
-
-      'string, number': function () {},
-      'number, string': function () {},
-      'boolean | string, boolean': function () {},
-      'any, ...string': function () {},
-      'string': function () {}
-    });
-
-    assert.deepEqual(Object.keys(fn.signatures).sort(), ['boolean,boolean', 'number', 'number,number']);
-  });
-
   it('should give a hint when composing with a wrongly cased type', function() {
     assert.throws(function () {
       var fn = typed({

--- a/test/construction.test.js
+++ b/test/construction.test.js
@@ -104,6 +104,11 @@ describe('construction', function() {
     assert.equal(fn('hi'), 'string');
   });
 
+  it('should ignore whitespace when creating a typed function with one argument', function() {
+    var fn = typed({' ... string ': A => 'string'});
+    assert.equal(fn('hi'), 'string');
+  });
+
   it('should create a typed function with two arguments', function() {
     var fn = typed({
       'string, boolean': function () {
@@ -282,9 +287,9 @@ describe('construction', function() {
     }, /Error: Unknown type "foo"/);
   });
 
-  it('should ignore types from typed.ignore', function() {
+  it('should ignore types marked so by typed.ignore', function() {
     var typed2 = typed.create();
-    typed2.ignore = ['string'];
+    typed2.ignore('string', true);
 
     var fn = typed2({
       'number': function () {},

--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -302,6 +302,22 @@ describe('conversion', function () {
     assert.equal(fn(2, 4, 5), 'numbers');
   });
 
+  it('should only end up with one way to convert a signature', function() {
+    var t2 = typed.create()
+    t2.addConversions([
+      {from: 'number', to: 'string', convert: n => 'N' + n},
+      {from: 'Array', to: 'boolean', convert: A => A.length > 0}
+    ]);
+    var ambiguous = t2({
+      'string, Array': (s, A) => 'one ' + s,
+      'number, boolean': (n, b) => 'two' + n,
+    }); // Could be two ways to apply to 'number, Array'; want only one
+    assert.strictEqual(ambiguous._typedFunctionData.signatures.length, 3)
+    assert.strictEqual(
+      t2.find(ambiguous, 'number, Array').apply(null, [0, [0]]),
+      'two0');
+  });
+
   it('should prefer conversions to any type argument', function() {
     var fn = typed({
       'number': function (a) {

--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -5,7 +5,7 @@ var strictEqualArray = require('./strictEqualArray');
 describe('conversion', function () {
 
   before(function () {
-    typed.conversions = [
+    typed.addConversions([
       {from: 'boolean', to: 'number', convert: function (x) {return +x;}},
       {from: 'boolean', to: 'string', convert: function (x) {return x + '';}},
       {from: 'number',  to: 'string', convert: function (x) {return x + '';}},
@@ -18,12 +18,12 @@ describe('conversion', function () {
         },
         fallible: true // TODO: not yet supported
       }
-    ];
+    ]);
   });
 
   after(function () {
     // cleanup conversions
-    typed.conversions = [];
+    typed.clearConversions();
   });
 
   it('should add conversions to a function with one argument', function() {
@@ -49,12 +49,14 @@ describe('conversion', function () {
       }
     };
 
-    assert.equal(typed2.conversions.length, 0);
+    assert.strictEqual(typed2._findType('string').conversionsTo.length, 0);
 
     typed2.addConversion(conversion);
 
-    assert.equal(typed2.conversions.length, 1);
-    assert.strictEqual(typed2.conversions[0], conversion);
+    assert.strictEqual(typed2._findType('string').conversionsTo.length, 1);
+    assert.strictEqual(
+      typed2._findType('string').conversionsTo[0].convert,
+      conversion.convert);
   });
 
   it('should throw an error when passing an invalid conversion object to addConversion', function() {
@@ -68,6 +70,14 @@ describe('conversion', function () {
     assert.throws(function () {typed2.addConversion({from: 2, to: 'string', convert: function () {}})}, errMsg);
     assert.throws(function () {typed2.addConversion({from: 'number', to: 2, convert: function () {}})}, errMsg);
     assert.throws(function () {typed2.addConversion({from: 'number', to: 'string', convert: 'foo'})}, errMsg);
+  });
+
+  it('should throw an error when attempting to add a conversion to unknown type', function () {
+    assert.throws(() => typed.addConversion({
+      from: 'number',
+      to: 'garbage',
+      convert: () => null
+    }), /Unknown type/);
   });
 
   it('should add conversions to a function with multiple arguments', function() {
@@ -95,10 +105,9 @@ describe('conversion', function () {
     assert.equal(fn('foo', true), 'string, number');
     assert.equal(fn('foo', 2), 'string, number');
     assert.equal(fn('foo', 'foo'), 'string, string');
-    assert.deepEqual(Object.keys(fn.signatures), [
-      'string,number',
-      'string,string'
-    ]);
+    assert.equal(Object.keys(fn.signatures).length, 2);
+    assert.ok('string,number' in fn.signatures);
+    assert.ok('string,string' in fn.signatures);
   });
 
   it('should add conversions to a function with rest parameters (1)', function() {
@@ -160,11 +169,11 @@ describe('conversion', function () {
 
   it('should add conversions to a function with rest parameters in a non-conflicting way', function() {
     var typed2 = typed.create();
-    typed2.conversions = [
+    typed2.addConversions([
       {from: 'boolean', to: 'number', convert: function (x) {return +x}},
       {from: 'string',  to: 'number', convert: function (x) {return parseFloat(x)}},
       {from: 'string', to: 'boolean', convert: function (x) {return !!x}}
-    ];
+    ]);
 
     // booleans can be converted to numbers, so the `...number` signature
     // will match. But the `...boolean` signature is a better (exact) match so that
@@ -202,9 +211,9 @@ describe('conversion', function () {
 
   it('should order conversions and type Object correctly ', function() {
     var typed2 = typed.create();
-    typed2.conversions = [
+    typed2.addConversion(
       {from: 'Date', to: 'string', convert: function (x) {return x.toISOString()}}
-    ];
+    );
 
     var fn = typed2({
       'string': function () {
@@ -346,18 +355,18 @@ describe('conversion', function () {
       assert.equal(fn(true, 'foo'), 'strings');
       assert.equal(fn('foo', true), 'strings');
 
-      assert.deepEqual(Object.keys(fn.signatures), [
-        'number,number',
-        'string,string',
-        'boolean,boolean'
-      ]);
+      assert.equal(Object.keys(fn.signatures).length, 3);
+      assert.ok('number,number' in fn.signatures);
+      assert.ok('string,string' in fn.signatures);
+      assert.ok('boolean,boolean' in fn.signatures);
     });
 
     it('should select the signatures with the conversion with the lowest index (1)', function () {
-      typed.conversions = [
+      typed.clearConversions();
+      typed.addConversions([
         {from: 'boolean', to: 'string', convert: function (x) {return x + '';}},
         {from: 'boolean', to: 'number', convert: function (x) {return x + 0;}}
-      ];
+      ]);
 
       // in the following typed function, a boolean input can be converted to
       // both a string or a number, which is both ok. In that case,
@@ -370,17 +379,17 @@ describe('conversion', function () {
 
       assert.strictEqual(fn(true), 'true');
 
-      assert.deepEqual(Object.keys(fn.signatures), [
-        'number',
-        'string'
-      ]);
+      assert.equal(Object.keys(fn.signatures).length, 2);
+      assert.ok('number' in fn.signatures);
+      assert.ok('string' in fn.signatures);
     });
 
     it('should select the signatures with the conversion with the lowest index (2)', function () {
-      typed.conversions = [
+      typed.clearConversions();
+      typed.addConversions([
         {from: 'boolean', to: 'number', convert: function (x) {return x + 0;}},
         {from: 'boolean', to: 'string', convert: function (x) {return x + '';}}
-      ];
+      ]);
 
       // in the following typed function, a boolean input can be converted to
       // both a string or a number, which is both ok. In that case,
@@ -395,11 +404,12 @@ describe('conversion', function () {
     });
 
     it('should select the signatures with least needed conversions (1)', function () {
-      typed.conversions = [
+      typed.clearConversions();
+      typed.addConversions([
         {from: 'number', to: 'boolean', convert: function (x) {return !!x }},
         {from: 'number', to: 'string', convert: function (x) {return x + '' }},
         {from: 'boolean', to: 'string', convert: function (x) {return x + '' }}
-      ];
+      ]);
 
       // in the following typed function, the number input can be converted to
       // both a string or a boolean, which is both ok. It should pick the
@@ -413,11 +423,12 @@ describe('conversion', function () {
     });
 
     it('should select the signatures with least needed conversions (2)', function () {
-      typed.conversions = [
+      typed.clearConversions();
+      typed.addConversions([
         {from: 'number', to: 'boolean', convert: function (x) {return !!x }},
         {from: 'number', to: 'string', convert: function (x) {return x + '' }},
         {from: 'boolean', to: 'string', convert: function (x) {return x + '' }}
-      ];
+      ]);
 
       // in the following typed function, the number input can be converted to
       // both a string or a boolean, which is both ok. It should pick the

--- a/test/conversion.test.js
+++ b/test/conversion.test.js
@@ -293,7 +293,7 @@ describe('conversion', function () {
     assert.equal(fn(2, 4, 5), 'numbers');
   });
 
-  it('should not apply conversions when having an any type argument', function() {
+  it('should prefer conversions to any type argument', function() {
     var fn = typed({
       'number': function (a) {
         return 'number';
@@ -304,7 +304,7 @@ describe('conversion', function () {
     });
 
     assert.equal(fn(2), 'number');
-    assert.equal(fn(true), 'any');
+    assert.equal(fn(true), 'number');
     assert.equal(fn('foo'), 'any');
     assert.equal(fn('{}'), 'any');
   });

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -68,6 +68,10 @@ describe('convert', function () {
       {
         name: 'string',
         test: x => typeof x === 'string'
+      },
+      {
+        name: 'boolean',
+        test: x => typeof x === 'boolean'
       }
     ])
 
@@ -83,6 +87,9 @@ describe('convert', function () {
 
     assert.strictEqual(typed2.convert('123.5', 'number'), 123.5)
     assert.strictEqual(typed2.convert('Infinity', 'number'), Infinity)
+
+    const check2 = typed2({boolean: () => 'yes'})
+    assert.throws(() => check2('x'), /TypeError:.*identifier.?|.?string/)
   });
 
   it('should not use an ignored type in performing a conversion', function () {

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -4,7 +4,7 @@ var typed = require('../typed-function');
 describe('convert', function () {
 
   before(function () {
-    typed.conversions = [
+    typed.addConversions([
       {from: 'boolean', to: 'number', convert: function (x) {return +x;}},
       {from: 'boolean', to: 'string', convert: function (x) {return x + '';}},
       {from: 'number',  to: 'string', convert: function (x) {return x + '';}},
@@ -17,12 +17,12 @@ describe('convert', function () {
         },
         fallible: true // TODO: not yet supported
       }
-    ];
+    ]);
   });
 
   after(function () {
     // cleanup conversions
-    typed.conversions = [];
+    typed.clearConversions();
   });
 
   it('should convert a value', function() {
@@ -30,13 +30,57 @@ describe('convert', function () {
     assert.strictEqual(typed.convert(true, 'string'), 'true');
     assert.strictEqual(typed.convert(true, 'number'), 1);
   });
-  
+
   it('should return same value when conversion is not needed', function () {
     assert.strictEqual(typed.convert(2, 'number'), 2);
     assert.strictEqual(typed.convert(true, 'boolean'), true);
   });
 
-  it('should throw an error when no conversion function is found', function() {
-    assert.throws(function () {typed.convert(2, 'boolean')}, /Error: Cannot convert from number to boolean/);
+  it('should throw an error when an unknown type is requested', function () {
+    assert.throws(function () { typed.convert(2, 'foo') }, /Unknown type.*foo/)
   });
+
+  it('should throw an error when no conversion function is found', function() {
+    assert.throws(
+      function () {typed.convert(2, 'boolean')},
+      /no conversions to boolean/);
+    assert.throws(
+      function () {typed.convert(null, 'string')},
+      /Cannot convert null to string/);
+  });
+
+  it('should pick the right conversion function when a value matches multiple types', () => {
+    // based on https://github.com/josdejong/typed-function/issues/128
+    const typed2 = typed.create()
+
+    typed2.clear()
+    typed2.addTypes([
+      {
+        name: 'number',
+        test: x => typeof x === 'number'
+      },
+      {
+        name: 'identifier',
+        test: x => (typeof x === 'string' &&
+          /^\p{Alphabetic}[\d\p{Alphabetic}]*$/u.test(x))
+      },
+      {
+        name: 'string',
+        test: x => typeof x === 'string'
+      }
+    ])
+
+    typed2.addConversion({ from: 'string', to: 'number', convert: x => parseFloat(x) })
+
+    const check = typed2('check', {
+      identifier: i => 'found an identifier: ' + i,
+      string: s => s + ' is just a string'
+    })
+
+    assert.strictEqual(check('xy33'), 'found an identifier: xy33')
+    assert.strictEqual(check('Wow!'), 'Wow! is just a string')
+
+    assert.strictEqual(typed2.convert('123.5', 'number'), 123.5)
+    assert.strictEqual(typed2.convert('Infinity', 'number'), Infinity)
+  })
 });

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -22,7 +22,6 @@ describe('convert', function () {
 
   after(function () {
     // cleanup conversions
-    typed.ignore('number', false);
     typed.clearConversions();
   });
 
@@ -90,13 +89,5 @@ describe('convert', function () {
 
     const check2 = typed2({boolean: () => 'yes'})
     assert.throws(() => check2('x'), /TypeError:.*identifier.?|.?string/)
-  });
-
-  it('should not use an ignored type in performing a conversion', function () {
-    typed.ignore('number', true);
-    assert.throws(() => typed.convert(2, 'string'), /Cannot convert/);
-    typed.ignore('number', false);
-    assert.strictEqual(typed.convert(2, 'string'), '2');
-    assert.strictEqual(typed.ignore('number'), false);
   });
 });

--- a/test/convert.test.js
+++ b/test/convert.test.js
@@ -22,6 +22,7 @@ describe('convert', function () {
 
   after(function () {
     // cleanup conversions
+    typed.ignore('number', false);
     typed.clearConversions();
   });
 
@@ -82,5 +83,13 @@ describe('convert', function () {
 
     assert.strictEqual(typed2.convert('123.5', 'number'), 123.5)
     assert.strictEqual(typed2.convert('Infinity', 'number'), Infinity)
-  })
+  });
+
+  it('should not use an ignored type in performing a conversion', function () {
+    typed.ignore('number', true);
+    assert.throws(() => typed.convert(2, 'string'), /Cannot convert/);
+    typed.ignore('number', false);
+    assert.strictEqual(typed.convert(2, 'string'), '2');
+    assert.strictEqual(typed.ignore('number'), false);
+  });
 });

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -154,18 +154,4 @@ describe('errors', function () {
     assert.throws(function () {fn2(true)},    /TypeError: Unexpected type of argument in function unnamed \(expected: string or number, actual: boolean, index: 0\)/);
     assert.throws(function () {fn2(2, true)}, /TypeError: Unexpected type of argument in function unnamed \(expected: string or number, actual: boolean, index: 1\)/);
   });
-
-  it('should not mention ignored types in an error ... (1)', function () {
-    const t2 = typed.create();
-    t2.ignore('number', true);
-    const tf = t2({'string': s => 'yes'});
-    assert.throws(() => tf(2), /Unexpected type.*actual:.any.*index:.0/);
-  });
-
-  it(' ... unless they are used in the function (1)', function () {
-    const t2 = typed.create();
-    const tf = t2({'number,string': (n,s) => 'both'});
-    t2.ignore('number', true);
-    assert.throws(() => tf(2, 2), /Unexpected type.*actual:.number.*index:.1/);
-  });
 });

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -154,4 +154,18 @@ describe('errors', function () {
     assert.throws(function () {fn2(true)},    /TypeError: Unexpected type of argument in function unnamed \(expected: string or number, actual: boolean, index: 0\)/);
     assert.throws(function () {fn2(2, true)}, /TypeError: Unexpected type of argument in function unnamed \(expected: string or number, actual: boolean, index: 1\)/);
   });
+
+  it('should not mention ignored types in an error ... (1)', function () {
+    const t2 = typed.create();
+    t2.ignore('number', true);
+    const tf = t2({'string': s => 'yes'});
+    assert.throws(() => tf(2), /Unexpected type.*actual:.any.*index:.0/);
+  });
+
+  it(' ... unless they are used in the function (1)', function () {
+    const t2 = typed.create();
+    const tf = t2({'number,string': (n,s) => 'both'});
+    t2.ignore('number', true);
+    assert.throws(() => tf(2, 2), /Unexpected type.*actual:.number.*index:.1/);
+  });
 });

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -139,7 +139,7 @@ describe('errors', function () {
 
   it('should only list matches of exact and convertable types', function() {
     var typed2 = typed.create();
-    typed2.conversions.push({
+    typed2.addConversion({
       from: 'number',
       to: 'string',
       convert: function (x) {

--- a/test/find.test.js
+++ b/test/find.test.js
@@ -84,10 +84,10 @@ describe('find', function () {
     assert.strictEqual(greetNumberSignature.fn, greeting);
     assert.strictEqual(greetNumber(42), 'Hi 42 much');
     assert.throws(
-      () => t2.findSignature(greet, 'number', 'exact'),
+      () => t2.findSignature(greet, 'number', typed.EXACT),
       /Signature not found/);
     assert.throws(
-      () => t2.find(greet, 'number', 'exact'),
+      () => t2.find(greet, 'number', typed.EXACT),
       TypeError);
     assert.strictEqual(t2.find(greet, 'string'), greeting);
   });
@@ -107,7 +107,7 @@ describe('find', function () {
       greetNumberSignature.implementation.apply(null, [2]),
       'Hi 2 much');
     assert.throws(
-      () => t2.find(greetRest, 'number', 'exact'),
+      () => t2.find(greetRest, 'number', typed.EXACT),
       /Signature not found/);
     const greetSN = t2.findSignature(greetRest, 'string,number');
     assert.strictEqual(greetSN.fn, greetAll);
@@ -115,7 +115,7 @@ describe('find', function () {
       greetSN.implementation.apply(null, ['JJ', 2]),
       'Hi JJ and 2 much');
     assert.throws(
-      () => t2.find(greetRest, 'string,number', 'exact'),
+      () => t2.find(greetRest, 'string,number', typed.EXACT),
       /Signature not found/);
     const greetNRNS = t2.findSignature(greetRest, 'number,...number|string');
     assert.strictEqual(greetNRNS.fn, greetAll);
@@ -123,7 +123,7 @@ describe('find', function () {
       greetNRNS.implementation.apply(null, [0, 'JJ', 2]),
       'Hi 0 much and JJ and 2 much');
     assert.throws(
-      () => t2.find(greetRest, 'number,...number|string', 'exact'),
+      () => t2.find(greetRest, 'number,...number|string', typed.EXACT),
       /Signature not found/);
   });
 });

--- a/test/find.test.js
+++ b/test/find.test.js
@@ -18,12 +18,27 @@ describe('find', function () {
   });
 
 
+  it('should findSignature from an array with types', function() {
+    assert.strictEqual(typed.findSignature(fn, ['number']).fn, a);
+    assert.strictEqual(typed.findSignature(fn, ['number', 'boolean']).fn, c);
+    assert.strictEqual(typed.findSignature(fn, ['any']).fn, d);
+    assert.strictEqual(typed.findSignature(fn, []).fn, e);
+  });
+
   it('should find a signature from an array with types', function() {
     assert.strictEqual(typed.find(fn, ['number']), a);
     assert.strictEqual(typed.find(fn, ['number', 'boolean']), c);
     assert.strictEqual(typed.find(fn, ['any']), d);
     assert.strictEqual(typed.find(fn, []), e);
 
+  });
+
+  it('should findSignature from a comma separated string with types', function() {
+    assert.strictEqual(typed.findSignature(fn, 'number').fn, a);
+    assert.strictEqual(typed.findSignature(fn, 'number,boolean').fn, c);
+    assert.strictEqual(typed.findSignature(fn, ' number, boolean ').fn, c); // with spaces
+    assert.strictEqual(typed.findSignature(fn, 'any').fn, d);
+    assert.strictEqual(typed.findSignature(fn, '').fn, e);
   });
 
   it('should find a signature from a comma separated string with types', function() {
@@ -40,9 +55,26 @@ describe('find', function () {
     }, /TypeError: Signature not found \(signature: fn\(number, number\)\)/);
   });
 
-
-  // TODO: implement support for matching non-exact signatures
-  //assert.strictEqual(typed.find(fn, ['Array']), d);
-
+  it('should handle non-exact matches as requested', function() {
+    const t2 = typed.create();
+    t2.addConversion({
+      from: 'number',
+      to: 'string',
+      convert: n => '' + n + ' much'
+    });
+    const greeting = s => 'Hi ' + s;
+    const greet = t2('greet', { string: greeting });
+    const greetNumberSignature = t2.findSignature(greet, 'number');
+    const greetNumber = t2.find(greet, 'number');
+    assert.strictEqual(greetNumberSignature.fn, greeting);
+    assert.strictEqual(greetNumber(42), 'Hi 42 much');
+    assert.throws(
+      () => t2.findSignature(greet, 'number', 'exact'),
+      /Signature not found/);
+    assert.throws(
+      () => t2.find(greet, 'number', 'exact'),
+      TypeError);
+    assert.strictEqual(t2.find(greet, 'string'), greeting);
+  });
 
 });

--- a/test/find.test.js
+++ b/test/find.test.js
@@ -17,6 +17,7 @@ describe('find', function () {
     '': e
   });
 
+  const EXACT = { exact: true };
 
   it('should findSignature from an array with types', function() {
     assert.strictEqual(typed.findSignature(fn, ['number']).fn, a);
@@ -84,10 +85,10 @@ describe('find', function () {
     assert.strictEqual(greetNumberSignature.fn, greeting);
     assert.strictEqual(greetNumber(42), 'Hi 42 much');
     assert.throws(
-      () => t2.findSignature(greet, 'number', typed.EXACT),
+      () => t2.findSignature(greet, 'number', EXACT),
       /Signature not found/);
     assert.throws(
-      () => t2.find(greet, 'number', typed.EXACT),
+      () => t2.find(greet, 'number', EXACT),
       TypeError);
     assert.strictEqual(t2.find(greet, 'string'), greeting);
   });
@@ -107,7 +108,7 @@ describe('find', function () {
       greetNumberSignature.implementation.apply(null, [2]),
       'Hi 2 much');
     assert.throws(
-      () => t2.find(greetRest, 'number', typed.EXACT),
+      () => t2.find(greetRest, 'number', EXACT),
       /Signature not found/);
     const greetSN = t2.findSignature(greetRest, 'string,number');
     assert.strictEqual(greetSN.fn, greetAll);
@@ -115,7 +116,7 @@ describe('find', function () {
       greetSN.implementation.apply(null, ['JJ', 2]),
       'Hi JJ and 2 much');
     assert.throws(
-      () => t2.find(greetRest, 'string,number', typed.EXACT),
+      () => t2.find(greetRest, 'string,number', EXACT),
       /Signature not found/);
     const greetNRNS = t2.findSignature(greetRest, 'number,...number|string');
     assert.strictEqual(greetNRNS.fn, greetAll);
@@ -123,7 +124,7 @@ describe('find', function () {
       greetNRNS.implementation.apply(null, [0, 'JJ', 2]),
       'Hi 0 much and JJ and 2 much');
     assert.throws(
-      () => t2.find(greetRest, 'number,...number|string', typed.EXACT),
+      () => t2.find(greetRest, 'number,...number|string', EXACT),
       /Signature not found/);
   });
 });

--- a/test/isTypedFunction.test.js
+++ b/test/isTypedFunction.test.js
@@ -1,0 +1,32 @@
+var assert = require('assert')
+var typed = require('../typed-function')
+
+describe('isTypedFunction', function () {
+
+  function a () {}
+  function b () {}
+
+  var fn = typed('fn', {
+    'number': a,
+    'string': b
+  });
+
+  it('should distinguish typed functions from others', () => {
+    assert.ok(typed.isTypedFunction(fn))
+    assert.strictEqual(typed.isTypedFunction(a), false)
+    assert.strictEqual(typed.isTypedFunction(7), false)
+  })
+
+  it('recognize typed functions from any typed instance', () => {
+    const parallel = typed.create()
+    const fn2 = parallel('fn', {
+      'number': b,
+      'string': a
+    })
+
+    assert.ok(parallel.isTypedFunction(fn2))
+    assert.ok(parallel.isTypedFunction(fn))
+    assert.ok(typed.isTypedFunction(fn2))
+  })
+
+})

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -61,9 +61,9 @@ describe('merge', function () {
 
   it('should not copy conversions as exact signatures', function () {
     var typed2 = typed.create();
-    typed2.conversions = [
+    typed2.addConversion(
       {from: 'string', to: 'number', convert: function (x) {return parseFloat(x)}}
-    ];
+    );
 
     var fn2 = typed2({'number': function (value) { return value }});
 

--- a/test/merge.test.js
+++ b/test/merge.test.js
@@ -109,7 +109,41 @@ describe('merge', function () {
     assert.equal(typed4.name, 'fn2');
   });
 
-  it('should allow recursive across merged signatures', function () {
+  it('should be able to use referTo when merging signatures from multiple typed-functions', function () {
+    function add1(a, b) {
+      return 'add1:' + (a + b);
+    }
+
+    function add2(a, b) {
+      return 'add2:' + (a + b);
+    }
+
+    var fn1 = typed({
+      'number,number': add1,
+      'string': typed.referTo('number,number', (fnNumberNumber) => {
+        return function (valuesString) {
+          const values = valuesString.split(',').map(Number);
+          return fnNumberNumber.apply(null, values);
+        }
+      })
+    });
+
+    var fn2 = typed({
+      'number,number': add2
+    });
+
+    assert.equal(fn1('2,3'), 'add1:5');
+    assert.equal(fn2(2, 3), 'add2:5');
+
+    var fn3 = typed({
+      ...fn1.signatures,
+      ...fn2.signatures, // <-- will override the 'number,number' signature of fn1 with the one of fn2
+    });
+
+    assert.equal(fn3('2,3'), 'add2:5');
+  });
+
+  it('should be able to use referToSelf across merged signatures', function () {
     var fn1 = typed({
       '...number': function (values) {
         var sum = 0;
@@ -121,18 +155,22 @@ describe('merge', function () {
     });
 
     var fn2 = typed({
-      '...string': function (values) {
-        var newValues = [];
-        for (var i = 0; i < values.length; i++) {
-          newValues[i] = parseInt(values[i], 10);
+      '...string': typed.referToSelf((self) => {
+        return function (values) {
+          assert.strictEqual(self, fn3); // only holds after merging fn1 and fn2
+
+          var newValues = [];
+          for (var i = 0; i < values.length; i++) {
+            newValues[i] = parseInt(values[i], 10);
+          }
+          return self.apply(null, newValues);
         }
-        return this.apply(null, newValues);
-      }
+      })
     });
 
     var fn3 = typed(fn1, fn2);
 
     assert.equal(fn3('1', '2', '3'), '6');
     assert.equal(fn3(1, 2, 3), 6);
-  })
+  });
 });

--- a/test/resolve.test.js
+++ b/test/resolve.test.js
@@ -1,0 +1,38 @@
+var assert = require('assert')
+var typed = require('../typed-function')
+
+describe('resolve', function () {
+
+  before(() => typed.addConversion({
+    from: 'boolean', to: 'string', convert: x => '' + x
+  }))
+
+  after(() => { typed.conversions = [] })
+
+  it('should choose the signature that direct execution would', () => {
+    const fn = typed({
+      'number': n => 'b ' + n,
+      'boolean': b => b ? 'c' : 'd',
+      'number, string': (n, s) => 'e ' + n + ' ' + s,
+      '...string': a => 'f ' + a.length,
+      '...': a => 'g ' + a.length
+    })
+    const examples = [
+      [3],
+      ['hello'],
+      [false],
+      [3, 'me'],
+      [0, true],
+      ['x', 'y', 'z'],
+      [false, 'y', false],
+      [[1]],
+      ['x', [1], 'z', 'w']
+    ]
+    for (example of examples) {
+      assert.strictEqual(
+        typed.resolve(fn, example).implementation.apply(null, example),
+        fn.apply(fn, example)
+      )
+    }
+  })
+})

--- a/test/resolve.test.js
+++ b/test/resolve.test.js
@@ -7,7 +7,7 @@ describe('resolve', function () {
     from: 'boolean', to: 'string', convert: x => '' + x
   }))
 
-  after(() => { typed.conversions = [] })
+  after(() => { typed.clearConversions() })
 
   it('should choose the signature that direct execution would', () => {
     const fn = typed({

--- a/test/rest_params.js
+++ b/test/rest_params.js
@@ -141,17 +141,17 @@ describe('rest parameters', function () {
     assert.equal(fn(2, 3), '...number');
     assert.equal(fn(2), '...number');
     assert.equal(fn({}), 'Object');
-    assert.deepEqual(Object.keys(fn.signatures), [
-      'Object',
-      '...number'
-    ]);
+
+    assert.equal(Object.keys(fn.signatures).length, 2);
+    assert.ok('Object' in fn.signatures);
+    assert.ok('...number' in fn.signatures);
   });
 
   it('should split rest params with conversions in two and order them correctly', function() {
     var typed2 = typed.create()
-    typed2.conversions = [
+    typed2.addConversion(
       {from: 'string', to: 'number', convert: function (x) {return parseFloat(x)}}
-    ];
+    );
 
     var fn = typed2({
       '...number': function (values) {

--- a/typed-function.js
+++ b/typed-function.js
@@ -248,23 +248,23 @@
         '_typedFunctionData' in entity;
     }
 
-    const EXACT = { exact: true };
     /**
      * Find a specific signature from a (composed) typed function, for example:
      *
      *   typed.findSignature(fn, ['number', 'string'])
      *   typed.findSignature(fn, 'number, string')
-     *   typed.findSignature(fn, 'number,string', typed.EXACT)
+     *   typed.findSignature(fn, 'number,string', {exact: true})
      *
      * This function findSignature will by default return the best match to
-     * the given signature, possibly employing type conversions. If the optional
-     * third argument is supplied as typed.EXACT (or any object for which
-     * the 'exact' property is true) only exact matches will be returned
-     * (i.e. signatures for which `fn` was directly defined).
+     * the given signature, possibly employing type conversions.
      *
-     * Note that any type matching `any` or one or more instances of TYPE
-     * matching `...TYPE` are considered exact matches in this regard, as
-     * no conversions are used.
+     * The (optional) third argument is a plain object giving options
+     * controlling the signature search. Currently the only implemented
+     * option is `exact`: if specified as true (default is false), only
+     * exact matches will be returned (i.e. signatures for which `fn` was
+     * directly defined). Note that a (possibly different) type matching
+     * `any`, or one or more instances of TYPE matching `...TYPE` are
+     * considered exact matches in this regard, as no conversions are used.
      *
      * This function returns a "signature" object, as does `typed.resolve()`,
      * which is a plain object with four keys: `params` (the array of parameters
@@ -277,8 +277,7 @@
      * @param {Function} fn                   A typed-function
      * @param {string | string[]} signature
      *     Signature to be found, can be an array or a comma separated string.
-     * @param {{exact: boolean}} exact
-     *     Should findSignature return only exact matches? (default: no)
+     * @param {object} options  Controls the signature search as documented
      * @return {{ params: Param[], fn: function, test: function, implementation: function }}
      *     Returns the matching signature, or throws an error when no signature
      *     is found.
@@ -360,20 +359,22 @@
      *
      *   typed.find(fn, ['number', 'string'])
      *   typed.find(fn, 'number, string')
-     *   typed.find(fn, 'number,string', typed.EXACT)
+     *   typed.find(fn, 'number,string', {exact: true})
      *
      * This function find will by default return the best match to
      * the given signature, possibly employing type conversions (and returning
-     * a function that will perform those conversions as needed). If the
-     * optional third argument is specified as typed.EXACT (or any object for
-     * which the 'exact' property is true), then only exact matches will be
-     * returned (i.e. signatures for which `fn` was directly defined).
+     * a function that will perform those conversions as needed). The
+     * (optional) third argument is a plain object giving options contolling
+     * the signature search. Currently only the option `exact` is implemented,
+     * which defaults to "false". If `exact` is specified as true, then only
+     * exact matches will be returned (i.e. signatures for which `fn` was
+     * directly defined). Uses of `any` and `...TYPE` are considered exact if
+     * no conversions are necessary to apply the corresponding function.
      *
      * @param {Function} fn                   A typed-function
      * @param {string | string[]} signature
      *     Signature to be found, can be an array or a comma separated string.
-     * @param {{exact: boolean}} exact
-     *     Should find() return only exact matches? (default: no)
+     * @param {object} options  Controls the signature match as documented
      * @return {function}
      *     Returns the function to call for the given signature, or throws an
      *     error if no match is found.
@@ -1874,7 +1875,6 @@
     typed.convert = convert;
     typed.findSignature = findSignature;
     typed.find = find;
-    typed.EXACT = EXACT;
     typed.isTypedFunction = isTypedFunction;
     typed.warnAgainstDeprecatedThis = true;
 

--- a/typed-function.js
+++ b/typed-function.js
@@ -179,7 +179,7 @@
      */
     function isTypedFunction(entity) {
       return entity && typeof entity === 'function' &&
-        '_isTypedFunction' in entity;
+        '_typedFunctionData' in entity;
     }
 
     /**
@@ -1194,11 +1194,8 @@
       fn.signatures = createSignaturesMap(signatures);
 
       // Store internal data for functions like resolve, find, etc.
-      fn._internal = { signatures: signatures };
-
-      // Also attach a property that is unlikely to collide with anything
-      // else so that we can check that this is a typed function:
-      fn._isTypedFunction = true
+      // Also serves as the flag that this is a typed-function
+      fn._typedFunctionData = { signatures: signatures };
 
       return fn;
     }
@@ -1545,7 +1542,7 @@
       if (!isTypedFunction(tf)) {
         throw new TypeError(NOT_TYPED_FUNCTION);
       }
-      const sigs = tf._internal.signatures;
+      const sigs = tf._typedFunctionData.signatures;
       for (var i = 0; i < sigs.length; ++i) {
         if (sigs[i].test(argList)) return sigs[i];
       }


### PR DESCRIPTION
This PR is a work in progress for a new, clean branch as an alternate Version 3 candidate. The primary goal to to implement the features of the first pass at Version 3 while keeping tight control over the efficiency of the library. To that end, every effort will be made to implement each feature in a single, clean commit, with before- and after-benchmarks of both typed-function benchmarks and the mathjs 'load all' benchmark reported in the discussion of this PR for each commit.

The scheduled features for V3 are, in the planned order of committing:

- [x] (A) Prefer conversions to "any"
- [x] (B) Add isTypedFunction() and resolve() methods
- [x] (C) Extend `typed.find()` to allow extraction of conversion-based methods (non-exact type match), with a flag restoring the prior behavior of exact type matches only [based on rough draft of adopting v3 in mathjs, this enhancement will significantly ease transition]
- [x] (D) Allow more efficient type conversion in the presence of overlapping types
- [x] (E) Fix `typed.find()` to handle matches to rest parameters, which it never previously did (e.g. typed.find(fn, 'number,number') should retrieve the '...number' signature if fn has one
- [x] (F) Review changes as requested on the changes from steps (C) and (D) above.
- [x] (G) Allow both the addition and _removal_ of types and type conversions [eases definition of typed-functions that need one-off conversions; the poster child for this is the typed-function definition of simplify(), which is greatly streamlined by introducing temporary conversions from string to Node and Object to Map; although a case can be made that string->Node should be added permanently throughout mathjs, the latter definitely should not.]
- [x] (H) Keep functions unbound, replace `this` with `typed.referTo` and `typed.referToSelf`
- [x] (I) Get a version of mathjs v11 passing all tests on top of this branch of typed-function
- [x] (J) Remove typed.EXACT
- [x] (K) Report all matching types in runtime type errors, instead of just the first matching type.
- [x] (L) Remove typed.ignore

Note that the refer mechanism is left until last, for ease of development/testing/benchmarking, since it's the one that requires a major refactor in mathjs.