### PR TITLE
fix: Avoid infinite loop in typed-function creation

### DIFF
--- a/test/construction.test.js
+++ b/test/construction.test.js
@@ -445,9 +445,19 @@ describe('construction', function() {
     assert.strictEqual(forward('10'), 'number:10')
   });
 
-  it('should throw an exception in case of circular referTo', () => {
+  it('should throw an exception in case of circular referTo', function () {
     assert.throws(
       () => { typed({
+        string: typed.referTo('number', fN => s => fN(s.length)),
+        number: typed.referTo('string', fS => n => fS(n.toString()))
+      })},
+      SyntaxError)
+  });
+
+  it('should throw with circular referTo and direct referToSelf', function () {
+    assert.throws(
+      () => { typed({
+        boolean: typed.referToSelf(self => b => b ? self(1) : self('false')),
         string: typed.referTo('number', fN => s => fN(s.length)),
         number: typed.referTo('string', fS => n => fS(n.toString()))
       })},

--- a/typed-function.js
+++ b/typed-function.js
@@ -1324,18 +1324,21 @@
      */
     function resolveReferences(functionList, signatureMap, self) {
       let resolvedFunctions = clearResolutions(functionList);
+      let isResolved = new Array(resolvedFunctions.length).fill(false);
       let leftUnresolved = true;
       while (leftUnresolved) {
         leftUnresolved = false;
         let nothingResolved = true;
         for (var i = 0; i < resolvedFunctions.length; ++i) {
-          const fn = resolvedFunctions[i]
+          if (isResolved[i]) continue;
+          const fn = resolvedFunctions[i];
 
           if (isReferToSelf(fn)) {
             resolvedFunctions[i] = fn.referToSelf.callback(self);
             // Preserve reference in case signature is reused someday:
             resolvedFunctions[i].referToSelf = fn.referToSelf;
-            nothingResolved = false
+            isResolved[i] = true;
+            nothingResolved = false;
           } else if (isReferTo(fn)) {
             const resolvedReferences = collectResolutions(
               fn.referTo.references, resolvedFunctions, signatureMap);
@@ -1344,6 +1347,7 @@
                 fn.referTo.callback.apply(this, resolvedReferences);
               // Preserve reference in case signature is reused someday:
               resolvedFunctions[i].referTo = fn.referTo;
+              isResolved[i] = true;
               nothingResolved = false;
             } else {
               leftUnresolved = true;


### PR DESCRIPTION
  Now when there are both full self-reference and referTo loops
  in the specification of a typed function, an error is thrown rather
  than typed() falling into an infinite loop.

  Resolves #157.